### PR TITLE
add virtualbox support to vagrantfile -- issue 46

### DIFF
--- a/components/centos/centos-with-kubernetes/Vagrantfile
+++ b/components/centos/centos-with-kubernetes/Vagrantfile
@@ -11,5 +11,9 @@ Vagrant.configure(2) do |config|
     libvirt.memory = 1048
   end
 
+  config.vm.provider "virtualbox" do |vbox|
+    vbox.memory = 1024
+  end
+
 end
 


### PR DESCRIPTION
This vagrantfile does work w/ libvirt and virtualbox: added bit to set RAM at 1024 in vbox, changed name to just "Vagrantfile", vagrant up --provider=libvirt and vagrant up --provider=virtualbox both work.
