### PR TITLE
Minor enhancement to the centos-with-kubernetes Vagrantfile

### DIFF
--- a/components/centos/centos-with-kubernetes/Vagrantfile
+++ b/components/centos/centos-with-kubernetes/Vagrantfile
@@ -1,19 +1,23 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
 
-#Vagrant file for libvirt/kvm provider
+#Vagrant file for libvirt/kvm and virtualbox provider
 
 Vagrant.configure(2) do |config|
   config.vm.box = "atomicapp/dev"
-  
-  config.vm.provider "libvirt" do |libvirt|
+
+  config.vm.provider "libvirt" do |libvirt, override|
     libvirt.driver = "kvm"
-    libvirt.memory = 1048
+    libvirt.memory = 1024
+    libvirt.cpus = 2
   end
 
-  config.vm.provider "virtualbox" do |vbox|
+  config.vm.provider "virtualbox" do |vbox, override|
     vbox.memory = 1024
+    vbox.cpus = 2
+
+    # Enable use of more than one virtual CPU in a virtual machine.
+    vbox.customize ["modifyvm", :id, "--ioapic", "on"]
   end
 
 end
-


### PR DESCRIPTION
Overide will use the settings in the Vagrant file even if
the host defaluts are different. Added 2 CPUs as default.
Also add flag to use vcpus for Virtualbox guests.

Signed-off-by: Lalatendu Mohanty lmohanty@redhat.com
