### PR TITLE
Updates kube-apiserver configuration for KUBE_ADMISSION_CONTROL

### DIFF
--- a/build_tools/kickstarts/centos-7-kubernetes-vagrant.ks
+++ b/build_tools/kickstarts/centos-7-kubernetes-vagrant.ks
@@ -93,6 +93,14 @@ tuned-adm profile virtual-guest
 echo "%vagrant ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers.d/vagrant
 sed -i "s/^.*requiretty/#Defaults requiretty/" /etc/sudoers
 
+# Fixes issue #71
+mkdir -p /etc/pki/kube-apiserver/
+openssl genrsa -out /etc/pki/kube-apiserver/serviceaccount.key 2048
+
+sed -i.back '/KUBE_API_ARGS=*/c\KUBE_API_ARGS="/etc/pki/kube-apiserver/serviceaccount.key"' /etc/kubernetes/apiserver
+
+sed -i.back '/KUBE_CONTROLLER_MANAGER_ARGS=*/c\KUBE_CONTROLLER_MANAGER_ARGS="--service_account_private_key_file=/etc/pki/kube-apiserver/serviceaccount.key"' /etc/kubernetes/controller-manager
+
 #enable Kubernetes master services
 #etcd kube-apiserver kube-controller-manager kube-scheduler
 

--- a/build_tools/kickstarts/centos-7-kubernetes-vagrant.ks
+++ b/build_tools/kickstarts/centos-7-kubernetes-vagrant.ks
@@ -97,7 +97,7 @@ sed -i "s/^.*requiretty/#Defaults requiretty/" /etc/sudoers
 mkdir -p /etc/pki/kube-apiserver/
 openssl genrsa -out /etc/pki/kube-apiserver/serviceaccount.key 2048
 
-sed -i.back '/KUBE_API_ARGS=*/c\KUBE_API_ARGS="/etc/pki/kube-apiserver/serviceaccount.key"' /etc/kubernetes/apiserver
+sed -i.back '/KUBE_API_ARGS=*/c\KUBE_API_ARGS="--service_account_key_file=/etc/pki/kube-apiserver/serviceaccount.key"' /etc/kubernetes/apiserver
 
 sed -i.back '/KUBE_CONTROLLER_MANAGER_ARGS=*/c\KUBE_CONTROLLER_MANAGER_ARGS="--service_account_private_key_file=/etc/pki/kube-apiserver/serviceaccount.key"' /etc/kubernetes/controller-manager
 


### PR DESCRIPTION
Fixes: https://github.com/projectatomic/adb-atomic-developer-bundle/issues/75

 Removes `ServiceAccount` from the value of `KUBE_ADMISSION_CONTROL` variable
 in /etc/kubernetes/apiserver
