### PR TITLE
Add no_timer_check with bootloader command

### DIFF
--- a/build_tools/kickstarts/centos-7-adb-vagrant.ks
+++ b/build_tools/kickstarts/centos-7-adb-vagrant.ks
@@ -12,7 +12,7 @@ selinux --enforcing
 timezone --utc America/New_York
 # The biosdevname and ifnames options ensure we get "eth0" as our interface
 # even in environments like virtualbox that emulate a real NW card
-bootloader --location=mbr --append="console=tty0 console=ttyS0,115200 net.ifnames=0 biosdevname=0"
+bootloader --location=mbr --append="no_timer_check console=tty0 console=ttyS0,115200 net.ifnames=0 biosdevname=0"
 zerombr
 clearpart --all --drives=vda
 


### PR DESCRIPTION
Fixes issue #145. no_timer_check helps to boot the vagrant box in
no kvm acceleration, no paravirtulaized clock environments
https://bugzilla.redhat.com/show_bug.cgi?id=1102592

Signed-off-by: Lalatendu Mohanty lmohanty@redhat.com
