### PR TITLE
Fix #128 (VM will start consistently after destroy/halt)

### DIFF
--- a/build_tools/kickstarts/centos-7-adb-vagrant.ks
+++ b/build_tools/kickstarts/centos-7-adb-vagrant.ks
@@ -93,6 +93,15 @@ tuned-adm profile virtual-guest
 echo "%vagrant ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers.d/vagrant
 sed -i "s/^.*requiretty/#Defaults requiretty/" /etc/sudoers
 
+# Fix for #128 (https://github.com/projectatomic/adb-atomic-developer-bundle/issues/128)
+cat > /etc/sysconfig/network-scripts/ifcfg-eth0 << EOF
+DEVICE="eth0"
+BOOTPROTO="dhcp"
+ONBOOT="yes"
+TYPE="Ethernet"
+PERSISTENT_DHCLIENT="yes"
+EOF
+
 systemctl enable docker
 
 groupadd docker


### PR DESCRIPTION
rebased by bexelbie to change the ks file modified

This replaces #144 
