### PR TITLE
Fixing /etc/hosts so that ADB hostname will resolve to 127.0.0.1

### DIFF
--- a/build_tools/kickstarts/centos-7-adb-vagrant.ks
+++ b/build_tools/kickstarts/centos-7-adb-vagrant.ks
@@ -54,6 +54,9 @@ tuned
 sed -i "/HWADDR/d" /etc/sysconfig/network-scripts/ifcfg-eth*
 sed -i "/UUID/d" /etc/sysconfig/network-scripts/ifcfg-eth*
 
+#Fixing https://github.com/projectatomic/adb-atomic-developer-bundle/issues/155
+echo "127.0.0.1     centos7-adb" >> /etc/hosts
+
 #Fixing issue #29
 cat << EOF > kube-apiserver.service
 [Unit]


### PR DESCRIPTION
Fixes issue #155

Signed-off-by: Lalatendu Mohanty lmohanty@redhat.com
