### PR TITLE
fix and re-organize docs/

### DIFF
--- a/docs/architecture.rst
+++ b/docs/architecture.rst
@@ -2,28 +2,46 @@
 Architecture and Roadmap for the ADB
 ====================================
 
-The Atomic Developer Bundle is a constantly evolving platform.  As such, this document should be considered carefully relative to both what is shipping, what issues and pull requests are open, and the date of last revision.  This document begins with the architecture for what will become version 2.0 of the ADB.  The roadmap that follows is quite speculative.
+The Atomic Developer Bundle is a constantly evolving platform.  As such, this
+document should be considered carefully relative to both what is shipping, what
+issues and pull requests are open, and the date of last revision. This document
+begins with the architecture for what will become version 2.0 of the ADB.  The
+roadmap that follows is quite speculative.
 
-The ADB is a stable CentOS Core installation with docker container and orchestration capability.  Many of the tools and features are provided by containers drawn from other sources.
+The ADB is a stable CentOS Core installation with docker container and
+orchestration capability. Many of the tools and features are provided by
+containers drawn from other sources.
 
-The ADB is not built on CentOS Atomic Host because there is a need for a fully writeable system to support the use case where the developer uses ``ssh`` to access the box and does all work on the inside.
+The ADB is not built on CentOS Atomic Host because there is a need for a fully
+writeable system to support the use case where the developer uses ``ssh`` to
+access the box and does all work on the inside.
 
 -----------------
 Version 2.0 Goals
 -----------------
 
-* Enabling host-based development tools such as Eclipse to access the build environments inside the ADB
-* Platform as a Service (PAAS) local testing and remote integration for OpenShift.
-* Enabling a workflow for define once, run anywhere that allows configuration for Openshift to be reused for Kubernetes
-* The Nulecule DevAssistant to make defining applications easier by providing a scaffold
-* Application definition enablement using the Atomic App Nulecule reference implementation
+* Enabling host-based development tools such as Eclipse to access the build
+  environments inside the ADB
+
+* Platform as a Service (PAAS) local testing and remote integration for
+  OpenShift.
+
+* Enabling a workflow for define once, run anywhere that allows configuration
+  for Openshift to be reused for Kubernetes
+
+* The Nulecule DevAssistant to make defining applications easier by providing a
+  scaffold
+
+* Application definition enablement using the Atomic App Nulecule reference
+  implementation
+
 * atomicapp-builder to drive atomicapp builds within the ADB
 
 *Deliverables:* Vagrant boxes for libvirt and VirtualBox
 
 These boxes contains the following components from the latest CentOS Core:
-  * CentOS7 minimal install
 
+  * CentOS7 minimal install
     * @development
     * deltarpm
     * rsync
@@ -36,31 +54,59 @@ These boxes contains the following components from the latest CentOS Core:
     * nfs-utils
     * PyYAML
     * libyaml-devel
-  * atomic - The `Atomic CLI <https://github.com/projectatomic/atomic>`_
+  * atomic - The `Atomic CLI`_
   * docker-registry
   * docker
-    
-    The docker daemon is configured to expose a TLS protected TCP port so that Vagrant host based tools can access it.  This is accomplished in three steps:
 
-    1. The systemd startup for docker inside of the ADB will generate TLS certificates if they don't already exist.
+    The docker daemon is configured to expose a TLS protected TCP port so that
+    Vagrant host based tools can access it.  This is accomplished in three
+    steps:
+
+    1. The systemd startup for docker inside of the ADB will generate TLS
+       certificates if they don't already exist.
+
     2. The user of the ADB exposes the docker daemon port in their Vagrantfile
-    3. The certificates are copied out by the `vagrant-adbinfo plugin <https://github.com/bexelbie/vagrant-adbinfo>`_.
+
+    3. The certificates are copied out by the `vagrant-adbinfo plugin`_
 
   * kubernetes
   * File Synchronization
 
     * Possibly via NFS for libvirt
     * Possibly via containerized extensions for VirtualBox
-    * Designed to make sure code can move from the Vagrant host to the ADB easily
+    * Designed to make sure code can move from the Vagrant host to the ADB
+      easily
+
+.. _Atomic CLI: https://github.com/projectatomic/atomic
+.. _vagrant-adbinfo plugin: https://github.com/bexelbie/vagrant-adbinfo
 
 Containers providing the following functionality:
-  * OpenShift - A PAAS environment for source-to-image container execution in a devops pattern
-  * `Atomic App <https://github.com/projectatomic/atomicapp>`_ - The `Nulecule <https://github.com/projectatomic/nulecule>`_ container application specification reference implementation
-  * `atomic-reactor <https://github.com/projectatomic/atomic-reactor>`_ - a python based container builder
-  * `DevAssistant <http://www.devassistant.org/>`_ - used to provide templates for `Dockerfiles <https://github.com/devassistant/dap-docker>`_ and `Nulecule Specification Files <https://github.com/devassistant/dap-nulecule>`_ - possibly using this container: https://github.com/devassistant/da-docker-nulecule - see `Issue #39 <https://github.com/projectatomic/adb-atomic-developer-bundle/issues/39>`_
+
+  * OpenShift - A PAAS environment for source-to-image container execution in a
+    devops pattern
+
+  * `Atomic App`_ - The `Nulecule`_ container application specification
+    reference implementation
+
+  * `atomic-reactor`_ - a python based container builder
+
+  * `DevAssistant`_ - used to provide templates for `Dockerfiles`_ and `Nulecule
+    Specification Files`_ - possibly using this container:
+    https://github.com/devassistant/da-docker-nulecule - see `Issue #39`_
+
+.. _Atomic App: https://github.com/projectatomic/atomicapp
+.. _atomic-reactor: https://github.com/projectatomic/atomic-reactor
+.. _DevAssistant: http://www.devassistant.org/
+.. _Dockerfiles: https://github.com/devassistant/dap-docker
+.. _Issue #39: https://github.com/projectatomic/adb-atomic-developer-bundle/issues/39
+.. _Nulecule: https://github.com/projectatomic/nulecule
+.. _Nulecule Specification Files: https://github.com/devassistant/dap-nulecule
 
 Additional Containers pre-loaded for quicker access:
-  * Latest Centos Base Image - see `Issue #25 <https://github.com/projectatomic/adb-atomic-developer-bundle/issues/25>`_
+
+  * Latest Centos Base Image - see `Issue #25`_
+
+.. _Issue #25: https://github.com/projectatomic/adb-atomic-developer-bundle/issues/25
 
 ----------------------
 Post Version 2.0 Ideas
@@ -68,8 +114,15 @@ Post Version 2.0 Ideas
 
 Beyond here be dragons and ideas which are not committed too.
 
-* Access to the `CentOS Container Community Pipeline <https://wiki.centos.org/ContainerPipeline>`_ for easy testing
+* Access to the `CentOS Container Community Pipeline`_ for easy testing
+
 * The ability to do multi-node testing using multiple ADB VMs
-* A build system inside the ADB to build/rebuild as needed based on code changes (Jenkins, etc.)
+
+* A build system inside the ADB to build/rebuild as needed based on code changes
+  (Jenkins, etc.)
+
 * Support for additional hypervisors
+
 * Delivery to AWS and GCE to ease developer access in some use cases
+
+.. _CentOS Container Community Pipeline: https://wiki.centos.org/ContainerPipeline

--- a/docs/building.rst
+++ b/docs/building.rst
@@ -2,18 +2,28 @@
 Building the ADB Vagrant Box
 ============================
 
-The Vagrant box is based on CentOS7. It is built using the latest packages from CentOS core.  Some components of the ADB will be delivered in containers and will use code drawn from upstream projects to add newer features.  Today no containers are including a fully built box.  The box can be built using the CentOS powered `Community Build System (CBS) <https://wiki.centos.org/HowTos/Commun  ityBuildSystem>`_.
+The Vagrant box is based on CentOS7. It is built using the latest packages from
+CentOS core.  Some components of the ADB will be delivered in containers and
+will use code drawn from upstream projects to add newer features. Today no
+containers are including a fully built box.  The box can be built using the
+CentOS powered `Community Build System (CBS)`_
+
+.. _Community Build System (CBS): https://wiki.centos.org/HowTos/CommunityBuildSystem
 
 To build the box:
 
-* Get access for building images in the CBS by following the directions here: http://wiki.centos.org/HowTos/CommunityBuildSystem
+* Get access for building images in the CBS by following the directions here:
+  http://wiki.centos.org/HowTos/CommunityBuildSystem
 
   **Note:** You need to request both "build" and "image" permissions
 
 * Checkout/git clone this repository ``git clone https://github.com/projectatomic/adb-atomic-developer-bundle``
 * ``cd adb-atomic-developer-bundle``
 * Run the ``./build_tools/build_scripts/do_vagrant_cbs.sh``
-  
-  **Note:** This script assumes you have a profile in your $HOME/.koji/config called "cbs"  If this is your only usage of koji, delete the ``-p cbs`` from the command in the script.  If you use multiple instances of koji, either rename your config for the CBS or change the script.
 
-Here is an example koji scratch build : http://cbs.centos.org/koji/taskinfo?taskID=13349
+  **Note:** This script assumes you have a profile in your $HOME/.koji/config
+  called "cbs"  If this is your only usage of koji, delete the ``-p cbs`` from
+  the command in the script. If you use multiple instances of koji, either
+  rename your config for the CBS or change the script.
+
+Here is an example koji scratch build: http://cbs.centos.org/koji/taskinfo?taskID=13349

--- a/docs/installing.rst
+++ b/docs/installing.rst
@@ -10,39 +10,57 @@ Two virtualization providers have been tested with the ADB.
 
 * Microsoft Windows and Mac OS X
 
-  The suggested virtualization provider is `VirtualBox <https://www.virtualbox.org/>`_.  Installation instructions are available `online <https://www.virtualbox.org/manual/UserManual.html>`_.  While the latest stable shipping release should work, the majority of testing has been done with version 5.0.0 on Mac OS X and 5.0.8 on Microsoft Windows.
+  The suggested virtualization provider is `VirtualBox`_. Installation
+  instructions are available `online`_. While the latest stable shipping release
+  should work, the majority of testing has been done with version 5.0.0 on Mac
+  OS X and 5.0.8 on Microsoft Windows.
+
+.. _VirtualBox: https://www.virtualbox.org
+.. _oneline: https://www.virtualbox.org/manual/UserManual.html
 
 * Fedora
 
-  Two different virtualization providers are supported on Linux, `VirtualBox <https://www.virtualbox.org/>`_ and `libvirt <http://libvirt.org/>`_.  The choice as to which to use should be driven by your preferences and environmental concerns and is outside of the scope of this document.  Both will work equally well in their default configuration.  You may wish to read the section on file synchronization when making this decision.
+  Two different virtualization providers are supported on Linux, `VirtualBox`_
+  and `libvirt <http://libvirt.org/>`_. The choice as to which to use should be
+  driven by your preferences and environmental concerns and is outside of the
+  scope of this document. Both will work equally well in their default
+  configuration. You may wish to read the section on file synchronization when
+  making this decision.
 
-  * VirtualBox installation instructions are available `online at the VirtualBox website <https://www.virtualbox.org/manual/ch02.html#startingvboxonlinux>`_.  Testing has been done with versions 4.3.34 and 5.0.0.
+  * VirtualBox installation instructions are available `online at the VirtualBox
+    website`_. Testing has been done with versions 4.3.34 and 5.0.0.
 
-    A summary of the installation is listed below:
-
-    ::
+    A summary of the installation is listed below::
 
       $ sudo dnf -y install dkms
       $ curl -O http://download.virtualbox.org/virtualbox/rpm/fedora/virtualbox.repo
       $ sudo mv virtualbox.repo /etc/yum.repos.d/
       $ sudo dnf -y install VirtualBox-4.3
       $ sudo /etc/init.d/vboxdrv setup
-    
-    While the latest stable release should work, the majority of testing has been done with version 4.3.30.
 
-  * Installing libvirt dependencies can be skipped as they are automatically installed together with `vagrant-libvirt` package.  Testing has been done with libvirt version 1.2.18 and vagrant-libvirt versions through to 0.0.32.
+    While the latest stable release should work, the majority of testing has
+    been done with version 4.3.30.
+
+  * Installing libvirt dependencies can be skipped as they are automatically
+    installed together with ``vagrant-libvirt`` package. Testing has been done
+    with libvirt version 1.2.18 and vagrant-libvirt versions through to 0.0.32.
 
 * CentOS
 
-  Two different virtualization providers are supported on Linux, `VirtualBox <https://www.virtualbox.org/>`_ and `libvirt <http://libvirt.org/>`_.  The choice as to which to use should be driven by your preferences and environmental concerns and is outside of the scope of this document.  Both will work equally well in their default configuration.  You may wish to read the section on file synchronization when making this decision.
+  Two different virtualization providers are supported on Linux, `VirtualBox`_
+  and `libvirt <http://libvirt.org/>`_. The choice as to which to use should be
+  driven by your preferences and environmental concerns and is outside of the
+  scope of this document. Both will work equally well in their default
+  configuration. You may wish to read the section on file synchronization when
+  making this decision.
 
-  * VirtualBox installation instructions are available `online at the VirtualBox website <https://www.virtualbox.org/manual/ch02.html#startingvboxonlinux>`_.  `CentOS specific instructions <https://wiki.centos.org/HowTos/Virtualization/VirtualBox>`_ are also available.
+  * VirtualBox installation instructions are available `online at the VirtualBox
+    website`_. `CentOS specific instructions`_ are also available.
 
-    While the latest stable release should work, the majority of testing has been done with version 4.3.30.
+    While the latest stable release should work, the majority of testing has
+    been done with version 4.3.30.
 
-    A summary of the installation is listed below:
-
-    ::
+    A summary of the installation is listed below::
 
       $ sudo yum -y install epel-release
       $ sudo yum -y install dkms
@@ -50,8 +68,13 @@ Two virtualization providers have been tested with the ADB.
       $ sudo mv virtualbox.repo /etc/yum.repos.d/
       $ sudo yum -y install VirtualBox-4.3
       $ sudo /etc/init.d/vboxdrv setup
-    
-  * Installing libvirt dependencies can be skipped as they are automatically installed together with `vagrant-libvirt` package.
+
+  * Installing libvirt dependencies can be skipped as they are automatically
+    installed together with ``vagrant-libvirt`` package.
+
+.. _CentOS specific instructions: https://wiki.centos.org/HowTos/Virtualization/VirtualBox
+.. _online at the VirtualBox website: https://www.virtualbox.org/manual/ch02.html#startingvboxonlinux
+.. _VirtualBox: https://www.virtualbox.org
 
 ------------------
 2. Install Vagrant
@@ -59,8 +82,10 @@ Two virtualization providers have been tested with the ADB.
 
 * Microsoft Windows
 
-  1. Follow the directions at `vagrantup.com <https://docs.vagrantup.com/v2/installation/index.html>`_  Testing has been done with version 1.7.4.
-  2. Install an ``ssh`` client.  Two good options are:
+  1. Follow the directions at `vagrantup.com`_  Testing has been done with
+     version 1.7.4.
+
+  2. Install an ``ssh`` client. Two good options are:
 
      * `Cygwin <https://cygwin.com/install.html>`_
      * `mingw <http://www.mingw.org/>`_
@@ -68,22 +93,23 @@ Two virtualization providers have been tested with the ADB.
 
 * Mac OS X
 
-  Follow the directions at `vagrantup.com <https://docs.vagrantup.com/v2/installation/index.html>`_  Testing has been done with version 1.7.4.
+  Follow the directions at `vagrantup.com`_ Testing has been done with version
+  1.7.4.
+
+.. _vagrantup.com: https://docs.vagrantup.com/v2/installation/index.html
 
 * Fedora 21/22/23
 
   Testing has been done with version 1.7.2.
 
-  To install Vagrant with VirtualBox in Fedora 21/22/23:
+  To install Vagrant with VirtualBox in Fedora 21/22/23::
 
-  ``$ sudo dnf install -y vagrant``
+    $ sudo dnf install -y vagrant
 
-  To install Vagrant with libvirt in Fedora 21/22/23:
+  To install Vagrant with libvirt in Fedora 21/22/23::
 
-  ::
-  
     $ sudo dnf install -y vagrant-libvirt
-    
+
     # Start libvirtd
     $ sudo systemctl start libvirtd
 
@@ -92,16 +118,16 @@ Two virtualization providers have been tested with the ADB.
 
 * CentOS
 
-  Vagrant packages are not available directly in CentOS core. However they are available through official CentOS `Software Collections <http://softwarecollections.org>`_ builds.
+  Vagrant packages are not available directly in CentOS core. However they are
+  available through official CentOS `Software Collections
+  <http://softwarecollections.org>`_ builds.
 
-  Here are the commands to get Vagrant in CentOS with `libvirt` support:
+  Here are the commands to get Vagrant in CentOS with `libvirt` support::
 
-  ::
-  
     $ sudo yum -y install centos-release-scl
     $ sudo yum -y install sclo-vagrant1
     $ sudo scl enable sclo-vagrant1 bash
-    
+
     # Start libvirtd
     $ sudo systemctl start libvirtd
 
@@ -112,26 +138,35 @@ Two virtualization providers have been tested with the ADB.
 3. Download the ADB
 -------------------
 
-There are two ways to download the ADB.  You can have ``vagrant`` do it for you the first time you install it or you can download it manually.
+There are two ways to download the ADB.  You can have ``vagrant`` do it for you
+the first time you install it or you can download it manually.
 
 * ``vagrant`` Initiated Download
 
-  The image is available at `https://atlas.hashicorp.com/projectatomic/boxes/adb <https://atlas.hashicorp.com/projectatomic/boxes/adb>`_. The ``vagrant`` program is capable of downloading the box the first time it is needed.  This happens when you first initialize a new vagrant environment.
- 
-  If you wish to use a project provided vagrant file you should first get the Vagrantfile as directed in `Using the Atomic Developer Bundle <using.rst>`_ in the *Using Custom Vagrantfiles for Specific Use Cases* section.
+  The image is available at https://atlas.hashicorp.com/projectatomic/boxes/adb.
+  The ``vagrant`` program is capable of downloading the box the first time it is
+  needed. This happens when you first initialize a new vagrant environment.
 
-  Otherwise you can issue a ``vagrant init`` command per the below.  You may wish to review the `Using the Atomic Developer Bundle <using.rst>`_ Documentation before starting the ADB, especially if you are using host-based tools.
+  If you wish to use a project provided vagrant file you should first get the
+  Vagrantfile as directed in `Using the Atomic Developer Bundle`_ in
+  the *Using Custom Vagrantfiles for Specific Use Cases* section.
+
+  Otherwise you can issue a ``vagrant init`` command per the below. You may wish
+  to review the `Using the Atomic Developer Bundle`_ documentation before
+  starting the ADB, especially if you are using host-based tools.
 
   ::
 
     # Add the image to vagrant
     $ vagrant init projectatomic/adb
 
+.. _Using the Atomic Developer Bundle: using.rst
+
 * Manually Downloading the Vagrant Box Image
 
-  Alternatively, you can manually download the vagrant box from `cloud.centos.org <http://cloud.centos.org/centos/7/atomic/images/>`_ using your web browser or curl.  For example:
-
-  ::
+  Alternatively, you can manually download the vagrant box from
+  `cloud.centos.org <http://cloud.centos.org/centos/7/atomic/images/>`_ using
+  your web browser or curl. For example::
 
     # To get the libvirt image
     $ wget http://cloud.centos.org/centos/7/atomic/images/AtomicDeveloperBundle-<latest>.box
@@ -139,12 +174,12 @@ There are two ways to download the ADB.  You can have ``vagrant`` do it for you 
     # To get the virtual box image
     $ wget http://cloud.centos.org/centos/7/atomic/images/AtomicDeveloperBundle-<latest>.box
 
-  Once you have downloaded the image, you can add it to ``vagrant`` with this command:
-
-  ::
+  Once you have downloaded the image, you can add it to ``vagrant`` with this
+  command::
 
     # Add the image to vagrant
     $ vagrant box add adb <local path to the downloded image>
 
+At this point your Atomic Developer Bundle installation is complete. You can
+find `Usage Information <using.rst>`_ in the documentation directory.
 
-At this point your Atomic Developer Bundle installation is complete.  You can find `Usage Information <using.rst>`_ in the documentation directory.

--- a/docs/motivation.md
+++ b/docs/motivation.md
@@ -2,29 +2,60 @@
 This Document Refers to Goals from Version 1.0
 ==============================================
 
-While it is useful to see where have come from, these motivations may no longer reflect the overall project.
+While it is useful to see where have come from, these motivations may no longer
+reflect the overall project.
 
 #Motivation
-Many people are considering using containers as a method of distributing applications. If you search the internet there is a lot of content similar to developing "hello world" but not much with regards to "enterprise container development." How is this different? Well, when developing with containers, many of the rules about application architecture, while not "different," are certainly more strictly enforced. For example, "decomposition of applications in to services." In a traditional application environment, on a virtual machine, for example, nothing really enforces that the services are actually independent until, during scale-out, you find out the hard way (unless you did really good testing). With containers, you find out immediately because the service isolation is enforced at any scale. 
 
-With this project, we are hoping to gather recommendations, architectural justifications, approaches, etc. that support development with containers after you have graduated from playing with containers and are truly looking to deliver enterprise-class applications.
+Many people are considering using containers as a method of distributing
+applications. If you search the internet there is a lot of content similar to
+developing "hello world" but not much with regards to "enterprise container
+development." How is this different? Well, when developing with containers, many
+of the rules about application architecture, while not "different," are
+certainly more strictly enforced. For example, "decomposition of applications in
+to services." In a traditional application environment, on a virtual machine,
+for example, nothing really enforces that the services are actually independent
+until, during scale-out, you find out the hard way \(unless you did really good
+testing\). With containers, you find out immediately because the service
+isolation is enforced at any scale.
 
-The project also provides tools to simplify re-architecting applications to leverage containers and the development of new applications based on containers. 
+With this project, we are hoping to gather recommendations, architectural
+justifications, approaches, etc. that support development with containers after
+you have graduated from playing with containers and are truly looking to deliver
+enterprise-class applications.
 
-The project specifically focuses on providing tools and documentation based on Fedora, RHEL, and CentOS, but much of the content should be equally applicable to other enterprise operating systems.
+The project also provides tools to simplify re-architecting applications to
+leverage containers and the development of new applications based on containers.
+
+The project specifically focuses on providing tools and documentation based on
+Fedora, RHEL, and CentOS, but much of the content should be equally applicable
+to other enterprise operating systems.
 
 #Approach
-The project has chosen Vagrant as a semi-universal way of describing development environments and, in related projects, made sure that Vagrant works well on the three target platforms (Fedora, RHEL, and CentOS). 
 
-In order to support this endeavor, the OS communities have started to make official "Vagrant boxes" available for both the main-line OS and the Atomic variants that are pre-configured to support container development.  
+The project has chosen Vagrant as a semi-universal way of describing development
+environments and, in related projects, made sure that Vagrant works well on the
+three target platforms \(Fedora, RHEL, and CentOS\).
 
- - Fedora: http://fedoraproject.org/wiki/Changes/Vagrant_Box_Atomic
+In order to support this endeavor, the OS communities have started to make
+official "Vagrant boxes" available for both the main-line OS and the Atomic
+variants that are pre-configured to support container development.
+
+ - Fedora: http://fedoraproject.org/wiki/Changes/Vagrant\_Box\_Atomic
  - CentOS: TBD
  - RHEL: TBD
 
-The project has provided [Vagrantfiles](http://docs.vagrantup.com/v2/vagrantfile/index.html) to setup both regular instances of the OSs as well as a "docker host" leveraging the [Vagrant Docker Provider](http://docs.vagrantup.com/v2/docker/index.html).
+The project has provided
+[Vagrantfiles](http://docs.vagrantup.com/v2/vagrantfile/index.html) to setup
+both regular instances of the OSs as well as a "docker host" leveraging the
+[Vagrant Docker Provider](http://docs.vagrantup.com/v2/docker/index.html).
 
-The project has also been working with Aaron's https://github.com/aweiteka/UATFramework which is an "implementation" of [Behave](http://pythonhosted.org/behave/) framework which can work across machines to provides tests. However, that work hasn't been integrated here yet and, currently, the only tests are some shell scripts. 
+The project has also been working with Aaron's
+https://github.com/aweiteka/UATFramework which is an "implementation" of
+[Behave](http://pythonhosted.org/behave/) framework which can work across
+machines to provides tests. However, that work hasn't been integrated here yet
+and, currently, the only tests are some shell scripts.
 
 #Next
+
 Let us know what else you think would be helpful.

--- a/docs/updating.rst
+++ b/docs/updating.rst
@@ -4,30 +4,33 @@ How to update the Atomic Developer Bundle to the latest version
 
 * If you are using the image from atlas.hashicorp.com
 
-  1. Check if a newer version of the box is available use this command:
+  1. Check if a newer version of the box is available use this command::
 
-     ``vagrant box outdated`` 
+     vagrant box outdated
 
-  2. If a newer version is available, the output should look like this:
+  2. If a newer version is available, the output should look like this::
 
-     ::
-
-     # vagrant box outdated
+        # vagrant box outdated
 
      Checking if box 'projectatomic/adb' is up to date...
-     A newer version of the box 'projectatomic/adb-testing' is available! You currently
-     have version '1.3.1'. The latest is version '1.3.2'. Run
-     `vagrant box update` to update.
+     A newer version of the box 'projectatomic/adb-testing' is available! You
+     currently have version '1.3.1'. The latest is version '1.3.2'. Run ``vagrant
+     box update`` to update.
 
+  3. If you see the above output, update the ADB Vagrant image with this
+     command::
 
-  3. If you see the above output, update the ADB Vagrant image with this command:
+     vagrant box update
 
-     ``vagrant box update``
+  4. Once the image is updated, you can restart the ADB with the new version
+     with this command::
 
-  4. Once the image is updated, you can restart the ADB with the new version with this command:
-
-     ``vagrant up``
+     vagrant up
 
 * If you are using image from cloud.centos.org
 
-  You will need to monitor the mailing list and other announcement points to determine if a new image is available.  If an image is available, download it and install it using the instructions in the `installation documentation <installing.rst>`_.
+  You will need to monitor the mailing list and other announcement points to
+  determine if a new image is available. If an image is available, download it
+  and install it using the instructions in the `installation documentation
+  <installing.rst>`_.
+

--- a/docs/using.rst
+++ b/docs/using.rst
@@ -5,108 +5,155 @@ Using the Atomic Developer Bundle
 Principles
 ==========
 
-* Consider the ADB to be ephemeral and do not store data in it long term.  It is recommended that you do the following:
+* Consider the ADB to be ephemeral and do not store data in it long term. It is
+  recommended that you do the following:
 
   * back up your code
   * use a source control system
   * mount your code into the box from your host system
 
-  Doing these things is beyond the scope of this document.  Consult your Operating System manuals and the `Vagrant <http://vagrantup.com/>`_ website for more details.
+  Doing these things is beyond the scope of this document. Consult your
+  Operating System manuals and the `Vagrant <http://vagrantup.com/>`_ website
+  for more details.
 
 Starting the Vagrant Box
 ========================
 
-1. Initialize a new Vagrant environment by creating a Vagrantfile.  You may find it helpful to first create a new directory for use by this environment.  Create the Vagrantfile with this command:
+1. Initialize a new Vagrant environment by creating a Vagrantfile. You may find
+   it helpful to first create a new directory for use by this environment.
+   Create the Vagrantfile with this command:
 
    ``vagrant init <box name>``
 
-   Box name is typically ``projectatomic/adb`` or whatever you named it when you loaded it manually.
+   Box name is typically ``projectatomic/adb`` or whatever you named it when you
+   loaded it manually.
 
-2. Edit the ``Vagrantfile`` to setup private networking.  The private network is used to expose ADB-based services, such as the docker daemon, to the host.  This is done by adding the following line in the ``Vagrant.configure`` section.
+2. Edit the ``Vagrantfile`` to setup private networking. The private network is
+   used to expose ADB-based services, such as the docker daemon, to the host.
+   This is done by adding the following line in the ``Vagrant.configure``
+   section.
 
    ``config.vm.network "private_network", type: "dhcp"``
 
 3. Start the Vagrant image with this command:
-    
+
    ``vagrant up``
 
-   **Note:** On Fedora and CentOS you may need to specify which virtualization provider to use.  For example, to use VirtualBox, the command would be ``vagrant up --provider virtualbox``
+   **Note:** On Fedora and CentOS you may need to specify which virtualization
+   provider to use.  For example, to use VirtualBox, the command would be
+   ``vagrant up --provider virtualbox``
 
 Using Custom Vagrantfiles for Specific Use Cases
 ================================================
 
-Custom Vagrant files are shipped for specific use cases.  The README files contain useful documentation and a quickstart guide.
+Custom Vagrant files are shipped for specific use cases. The README files
+contain useful documentation and a quickstart guide.
 
-- Docker for use with host-based tools, such as Eclipse and the docker CLI, or via ``vagrant ssh``
-  - `Vagrantfile <../components/centos/centos-docker-base-setup/Vagrantfile>`_
-  - `README <../components/centos/centos-docker-base-setup/README.rst>`_
-- Docker and Kubernetes for use with host-based tools or via ``vagrant ssh``
-  - `Vagrantfile <../components/centos/centos-k8s-singlenode-setup/Vagrantfile>`_
-  - `README <../components/centos/centos-k8s-singlenode-setup/README.rst>`_
-- OpenShift Origin for use with host-based tools or via ``vagrant ssh``
-  - `Vagrantfile <../components/centos/centos-openshift-setup/Vagrantfile>`_
-  - `README <../components/centos/centos-openshift-setup/README.rst>`_
+* Docker for use with host-based tools, such as Eclipse and the docker CLI, or
+  via ``vagrant ssh``
+
+  * `Vagrantfile <../components/centos/centos-docker-base-setup/Vagrantfile>`_
+  * `README <../components/centos/centos-docker-base-setup/README.rst>`_
+
+* Docker and Kubernetes for use with host-based tools or via ``vagrant ssh``
+
+  * `Vagrantfile <../components/centos/centos-k8s-singlenode-setup/Vagrantfile>`_
+  * `README <../components/centos/centos-k8s-singlenode-setup/README.rst>`_
+
+* OpenShift Origin for use with host-based tools or via ``vagrant ssh``
+
+  * `Vagrantfile <../components/centos/centos-openshift-setup/Vagrantfile>`_
+  * `README <../components/centos/centos-openshift-setup/README.rst>`_
 
 Using the box with Host-based Tools (Eclipse and CLIs)
 ======================================================
 
-Many users may wish to use the ADB from their Host so it can seamlessly interact with their files, preferred development tools, etc.
+Many users may wish to use the ADB from their Host so it can seamlessly interact
+with their files, preferred development tools, etc.
 
-Today, the ADB exposures the docker daemon port so that tools like Eclipse and the docker CLI can interact with it.  For security reasons, the docker daemon is TLS protected, so in addition to exposing the port you must configure the docker command on the host to use TLS and the right port.  This can be done easily with the ``vagrant-adbinfo`` Vagrant plugin.  The plugin will provide you with the TLS certificate and the proper environment variables.
+Today, the ADB exposures the docker daemon port so that tools like Eclipse and
+the docker CLI can interact with it. For security reasons, the docker daemon is
+TLS protected, so in addition to exposing the port you must configure the docker
+command on the host to use TLS and the right port. This can be done easily with
+the ``vagrant-adbinfo`` Vagrant plugin. The plugin will provide you with the TLS
+certificate and the proper environment variables.
 
-1. Install the ``vagrant-adbinfo`` plugin in order to get easy access to the correct environment variables and the TLS certificates.
+1. Install the ``vagrant-adbinfo`` plugin in order to get easy access to the
+   correct environment variables and the TLS certificates.
 
-   ``vagrant plugin install vagrant-adbinfo``
+   ::
 
-   More information about the vagrant-adbinfo plugin is `available in the source repository <https://github.com/projectatomic/adbinfo>`_
+       vagrant plugin install vagrant-adbinfo
 
-2. Get the correct environment variables and TLS certificates from the plugin.  The example below shows the command and the output for Linux::
+   More information about the vagrant-adbinfo plugin is `available in the source
+   repository`_.
+
+.. _available in the source repository: https://github.com/projectatomic/vagrant-adbinfo
+
+2. Get the correct environment variables and TLS certificates from the plugin.
+   The example below shows the command and the output for Linux::
 
     $ vagrant adbinfo
     Set the following environment variables to enable access to the
     docker daemon running inside of the vagrant virtual machine:
-    
+
     export DOCKER_HOST=tcp://172.13.14.1:5555
     export DOCKER_CERT_PATH=/home/bexelbie/Repositories/vagrant-adbinfo/.vagrant/machines/default/virtualbox/.docker
     export DOCKER_TLS_VERIFY=1
     export DOCKER_MACHINE_NAME="90d3e96"
 
-   *Note:* The output is similar for Mac OS X.  On Microsoft Windows the environment is setup using the `setx` command.
+   *Note:* The output is similar for Mac OS X. On Microsoft Windows the
+   environment is setup using the `setx` command.
 
-   Setting these environment variables allows program, such as Eclipse and the docker CLI to access the docker daemon.
+   Setting these environment variables allows program, such as Eclipse and the
+   docker CLI to access the docker daemon.
 
 3. Begin developing.
-   
-   If you are using the docker CLI, you can just run it from the command line and it will work as expected.  If you need to download a copy of the docker CLI, you can find it listed as a "client binary" download in the official `Docker Repositories <https://github.com/docker/docker/releases>`_.
+
+   If you are using the docker CLI, you can just run it from the command line
+   and it will work as expected.  If you need to download a copy of the docker
+   CLI, you can find it listed as a "client binary" download in the official
+   `Docker Repositories <https://github.com/docker/docker/releases>`_.
 
    If you are using Eclipse, you should follow these steps:
 
    **Note:** Testing has been done with Eclipse 4.5.0.
 
-   1. Install the `Docker Tooling <http://www.eclipse.org/community/eclipse_newsletter/2015/june/article3.php>`_ plugin.
+   1. Install the `Docker Tooling`_ plugin.
 
-   2. Enable the three Docker Views (Docker Explorer, Docker Containers, and Docker Images) by choosing Windows->Show Views->Others.
+   2. Enable the three Docker Views (Docker Explorer, Docker Containers, and
+      Docker Images) by choosing Windows->Show Views->Others.
 
    3. Enable the Console by choosing Windows->Show Views->Console.
 
-   4. In the ``Docker Explorer`` view, click to add a connection.  You should provide a "connection name."  If your Environment Variables are set correctly, the remaining fields will autopopulate.  If not, using the output from ``vagrant adbinfo``, put the DOCKER_HOST variable in the "TCP Connection" field and the DOCKER_CERT_PATH in the Authentication Section Path.
+   4. In the ``Docker Explorer`` view, click to add a connection. You should
+      provide a "connection name." If your Environment Variables are set
+      correctly, the remaining fields will autopopulate. If not, using the
+      output from ``vagrant adbinfo``, put the DOCKER_HOST variable in the "TCP
+      Connection" field and the DOCKER_CERT_PATH in the Authentication Section
+      Path.
 
-   5. You can test the connection and then accept the results.  At this point, you are ready to use the ADB with Eclipse.
+   5. You can test the connection and then accept the results. At this point,
+      you are ready to use the ADB with Eclipse.
 
+.. _Docker Tooling: http://www.eclipse.org/community/eclipse_newsletter/2015/june/article3.php
 
 Using the box via SSH
 =====================
-   
-Today most users will do their work inside the Vagrant box.  Access the box by using ``ssh`` to login to it with the following command:
 
-``vagrant ssh``
+Today most users will do their work inside the Vagrant box.  Access the box by
+using ``ssh`` to login to it with the following command::
 
-You are now at a shell prompt inside the Vagrant box.  You can now execute commands and use the tools provided.
+    vagrant ssh
+
+You are now at a shell prompt inside the Vagrant box. You can now execute
+commands and use the tools provided.
 
 Using ``docker``
 ################
 
-The ADB provides a full container environment and is running both ``docker`` and ``kubernetes``.  All standard commands will work, for example::
+The ADB provides a full container environment and is running both ``docker`` and
+``kubernetes``. All standard commands will work, for example::
 
    docker pull centos
    docker run -t -i centos /bin/bash
@@ -119,21 +166,30 @@ Details on these projects can be found at these urls:
 * Atomic App: https://github.com/projectatomic/atomicapp
 * Nulecule: https://github.com/projectatomic/nulecule
 
-The `helloapache <https://registry.hub.docker.com/u/projectatomic/helloapache/>`_ example can be used to test your installation.
+The `helloapache`_ example can be used to test your installation.
 
-*Note:* Many Nulecule examples expect a working kubernetes environment.  To setup a single node kubernetes environment use the `Vagrantfile <../components/centos/centos-k8s-singlenode-setup/Vagrantfile>`_ and refer the corresponding `README <../components/centos/centos-k8s-singlenode-setup/README.rst>`_
+*Note:* Many Nulecule examples expect a working kubernetes environment. To setup
+a single node kubernetes environment use the `Vagrantfile`_ and refer the
+corresponding `README`_.
 
-You can verify your environment with by executing ``kubectl get nodes``.  The expected output is:
+You can verify your environment with by executing ``kubectl get nodes``. The
+expected output is::
 
-::
+    $ kubectl get nodes
+    NAME        LABELS                             STATUS
+    127.0.0.1   kubernetes.io/hostname=127.0.0.1   Ready
 
-  $ kubectl get nodes                                                                         
-  NAME        LABELS                             STATUS
-  127.0.0.1   kubernetes.io/hostname=127.0.0.1   Ready
+.. _helloapache: https://registry.hub.docker.com/u/projectatomic/helloapache/
+.. _README: ../components/centos/centos-k8s-singlenode-setup/README.rst
+.. _Vagrantfile: ../components/centos/centos-k8s-singlenode-setup/Vagrantfile
 
 Destroying the Vagrant Box
 ==========================
 
-Warning, this will destroy any data you have stored in the Vagrant box.  You will not be able to restart this instance and will have to create a new one using ``vagrant up``.
+Warning, this will destroy any data you have stored in the Vagrant box. You will
+not be able to restart this instance and will have to create a new one using
+``vagrant up``.
 
-``vagrant destroy``
+::
+
+    vagrant destroy


### PR DESCRIPTION
- re-organize format of *.rst and *.md in docs/
- fix error link of vagrant-adbinfo in using.rst
- remove trailing whitespaces

This change is intended to make document more readable even in a text
editor.
