### PR TITLE
Fix #183, added version info for ADB

### DIFF
--- a/build_tools/kickstarts/centos-7-adb-vagrant.ks
+++ b/build_tools/kickstarts/centos-7-adb-vagrant.ks
@@ -54,6 +54,10 @@ tuned
 sed -i "/HWADDR/d" /etc/sysconfig/network-scripts/ifcfg-eth*
 sed -i "/UUID/d" /etc/sysconfig/network-scripts/ifcfg-eth*
 
+# Add adb version info to consumed by adbinfo
+# https://github.com/projectatomic/adb-atomic-developer-bundle/issues/183
+echo "ADB_VERSION=\"2.0\"" >> /etc/os-release
+
 #Fixing https://github.com/projectatomic/adb-atomic-developer-bundle/issues/155
 echo "127.0.0.1     centos7-adb" >> /etc/hosts
 

--- a/build_tools/kickstarts/centos-7-adb-vagrant.ks
+++ b/build_tools/kickstarts/centos-7-adb-vagrant.ks
@@ -58,7 +58,7 @@ sed -i "/UUID/d" /etc/sysconfig/network-scripts/ifcfg-eth*
 # https://github.com/projectatomic/adb-atomic-developer-bundle/issues/183
 echo "VARIANT=\"Atomic Developer Bundle (ADB)\"" >> /etc/os-release
 echo "VARIANT_ID=\"adb\"" >> /etc/os-release
-echo "VARIANT_VERSION=\"2.0\"" >> /etc/os-release
+echo "VARIANT_VERSION=\"1.6.0\"" >> /etc/os-release
 
 #Fixing https://github.com/projectatomic/adb-atomic-developer-bundle/issues/155
 echo "127.0.0.1     centos7-adb" >> /etc/hosts

--- a/build_tools/kickstarts/centos-7-adb-vagrant.ks
+++ b/build_tools/kickstarts/centos-7-adb-vagrant.ks
@@ -56,7 +56,9 @@ sed -i "/UUID/d" /etc/sysconfig/network-scripts/ifcfg-eth*
 
 # Add adb version info to consumed by adbinfo
 # https://github.com/projectatomic/adb-atomic-developer-bundle/issues/183
-echo "ADB_VERSION=\"2.0\"" >> /etc/os-release
+echo "VARIANT=\"Atomic Developer Bundle (ADB)\"" >> /etc/os-release
+echo "VARIANT_ID=\"adb\"" >> /etc/os-release
+echo "VARIANT_VERSION=\"2.0\"" >> /etc/os-release
 
 #Fixing https://github.com/projectatomic/adb-atomic-developer-bundle/issues/155
 echo "127.0.0.1     centos7-adb" >> /etc/hosts


### PR DESCRIPTION
We appended ADB version info to `os-release` so that `vagrant-adbinfo` consume it and provide required details to user.
