### PR TITLE
Address #140 OpenShift service script on VM

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -3,3 +3,4 @@ Lalatendu Mohanty <lmohanty@redhat.com> @LalatenduMohanty
 Langdon White <langdon@redhat.com> @whitel
 Navid Shaikh <nshaikh@redhat.com> @navidshaikh
 Josef Strzibny <strzibny@strzibny.name> @strzibny
+Praveen Kumar <prkumar@redhat.com> @praveenkumar

--- a/components/centos/centos-openshift-setup/service_script/openshift
+++ b/components/centos/centos-openshift-setup/service_script/openshift
@@ -95,7 +95,7 @@ for n in ${binaries[@]}; do
         docker run --rm --entrypoint=/bin/cat openshift /usr/bin/${n} > /usr/bin/${n}
         chmod +x /usr/bin/${n}
 done
-echo "export OPENSHIFT_DIR=#{ORIGIN_DIR}/openshift.local.config/master" > /etc/profile.d/openshift.sh
+echo "export OPENSHIFT_DIR=${ORIGIN_DIR}/openshift.local.config/master" > /etc/profile.d/openshift.sh
 
 # In a re-provision scenario we want to make sure the old container is removed
 rm_openshift_container

--- a/components/centos/centos-openshift-setup/service_script/openshift
+++ b/components/centos/centos-openshift-setup/service_script/openshift
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+
+# Prepare, configure and start OpenShift
+
+set -o pipefail
+set -o nounset
+
+export ORIGIN_DIR="/var/lib/origin"
+export OPENSHIFT_DIR=${ORIGIN_DIR}/openshift.local.config/master
+export KUBECONFIG=${OPENSHIFT_DIR}/admin.kubeconfig
+
+
+# The Docker registry from where we pull the OpenShift Enterprise Docker image
+echo "export KUBECONFIG=${OPENSHIFT_DIR}/admin.kubeconfig" > /etc/profile.d/kubeconf.sh
+
+function usage
+{
+    echo "usage: openshift [[[-r route ] [-host hostname]] | [-h]]"
+}
+
+# Command line options
+
+while [ $# -gt 0 ]; do
+    case $1 in
+        -r | --route )          shift
+                                route=$1
+                                ;;
+        -host | --hostname )    shift 
+                                host=$1
+                                ;;
+        -h | --help )           usage
+                                exit
+                                ;;
+        * )                     usage
+                                exit 1
+    esac
+    shift
+done
+
+
+########################################################################
+# Helper function to start OpenShift as container
+#
+# All passed paramters are passed through ti
+########################################################################
+start_openshift() {
+        docker run --name "openshift" --privileged --net=host --pid=host \
+        -v /:/rootfs:ro \
+        -v /var/run:/var/run:rw \
+        -v /sys:/sys:ro \
+        -v /var/lib/docker:/var/lib/docker:rw \
+        -v ${ORIGIN_DIR}/openshift.local.volumes:${ORIGIN_DIR}/openshift.local.volumes:z \
+        -v ${ORIGIN_DIR}/openshift.local.config:${ORIGIN_DIR}/openshift.local.config:z \
+        -v ${ORIGIN_DIR}/openshift.local.etcd:${ORIGIN_DIR}/openshift.local.etcd:z \
+        openshift start "$@"
+}
+
+########################################################################
+# Helper function to remove existing openshift container
+########################################################################
+rm_openshift_container() {
+    if docker inspect openshift &>/dev/null; then
+        docker rm -f -v openshift > /dev/null 2>&1
+    fi
+}
+
+########################################################################
+# Helper function to wait for OpenShift config file generation
+########################################################################
+wait_for_config_files() {
+  echo "[INFO] Waiting for OpenShift config files to be created"
+  for i in {1..6}; do
+    if [ ! -f ${1} ] || [ ! -f ${2} ]; then
+      echo "[INFO] ..."
+      sleep 5
+    else
+      break
+    fi
+  done
+  if [ ! -f ${1} ] || [ ! -f ${2} ]; then
+    >&2 echo "[ERROR] Unable to create OpenShift config files"
+    docker logs openshift
+    exit 1
+  fi
+}
+
+########################################################################
+# Main
+########################################################################
+# Copy OpenShift CLI tools to the VM
+binaries=(oc oadm)
+for n in ${binaries[@]}; do
+        [ -f /usr/bin/${n} ] && continue
+        echo "[INFO] Copying the OpenShift '${n}' binary to host /usr/bin/${n}"
+        docker run --rm --entrypoint=/bin/cat openshift /usr/bin/${n} > /usr/bin/${n}
+        chmod +x /usr/bin/${n}
+done
+echo "export OPENSHIFT_DIR=#{ORIGIN_DIR}/openshift.local.config/master" > /etc/profile.d/openshift.sh
+
+# In a re-provision scenario we want to make sure the old container is removed
+rm_openshift_container
+
+# First start OpenShift to just write the config files
+master_config=${OPENSHIFT_DIR}/master-config.yaml
+node_config=${ORIGIN_DIR}/openshift.local.config/node-$(hostname)/node-config.yaml
+
+if [ ! -f $master_config ]; then
+
+    # Prepare directories for bind-mounting
+    dirs=(openshift.local.volumes openshift.local.config openshift.local.etcd)
+    for d in ${dirs[@]}; do
+            mkdir -p ${ORIGIN_DIR}/${d} && chcon -Rt svirt_sandbox_file_t ${ORIGIN_DIR}/${d}
+    done
+
+    echo "[INFO] Preparing OpenShift config"
+    start_openshift --write-config=${ORIGIN_DIR}/openshift.local.config > /dev/null 2>&1
+    wait_for_config_files ${master_config} ${node_config}
+
+    # Now we need to make some adjustments to the config
+    echo "[INFO] Configuring OpenShift via ${master_config}"
+    sed -i.orig -e "s/\(.*subdomain:\).*/\1 $route/" ${master_config} \
+    -e "s/\(.*masterPublicURL:\).*/\1 https:\/\/$host:8443/g" \
+    -e "s/\(.*publicURL:\).*/\1 https:\/\/$host:8443\/console\//g" \
+    -e "s/\(.*assetPublicURL:\).*/\1 https:\/\/$host:8443\/console\//g"
+
+    # Remove the container
+    rm_openshift_container
+fi
+
+# Now we start the server pointing to the prepared config files
+echo "[INFO] Starting OpenShift server"
+start_openshift --master-config="${master_config}" --node-config="${node_config}"

--- a/components/centos/centos-openshift-setup/service_script/openshift.service
+++ b/components/centos/centos-openshift-setup/service_script/openshift.service
@@ -4,7 +4,7 @@ Documentation=https://docs.openshift.org/
 After=docker.service
 Requires=docker.service
 Conflicts=etcd kube-apiserver kube-controller-manager kube-scheduler kube-proxy kubelet
- 
+
 [Service]
 TimeoutStartSec=0
 Restart=always
@@ -13,10 +13,11 @@ ExecStartPre=-/usr/bin/docker stop openshift
 ExecStartPre=-/usr/bin/docker rm openshift
 ExecStartPre=-/usr/bin/docker tag ${DOCKER_REGISTRY}/${IMAGE} openshift
 ExecStart=/usr/bin/sh -x /opt/adb/openshift $OPTIONS
+ExecStartPost=/bin/sleep 20
 ExecStartPost=/usr/bin/sh -x /opt/adb/openshift_provision
 KillMode=process
 Restart=on-failure
-RestartSec=50s
-   
+RestartSec=30s
+
 [Install]
 WantedBy=multi-user.target

--- a/components/centos/centos-openshift-setup/service_script/openshift.service
+++ b/components/centos/centos-openshift-setup/service_script/openshift.service
@@ -1,0 +1,22 @@
+[Unit]
+Description=Docker Application Container for OpenShift
+Documentation=https://docs.openshift.org/
+After=docker.service
+Requires=docker.service
+Conflicts=etcd kube-apiserver kube-controller-manager kube-scheduler kube-proxy kubelet
+ 
+[Service]
+TimeoutStartSec=0
+Restart=always
+EnvironmentFile=-/etc/sysconfig/openshift_option
+ExecStartPre=-/usr/bin/docker stop openshift
+ExecStartPre=-/usr/bin/docker rm openshift
+ExecStartPre=-/usr/bin/docker tag ${DOCKER_REGISTRY}/${IMAGE} openshift
+ExecStart=/usr/bin/sh -x /opt/adb/openshift $OPTIONS
+ExecStartPost=/usr/bin/sh -x /opt/adb/openshift_provision
+KillMode=process
+Restart=on-failure
+RestartSec=50s
+   
+[Install]
+WantedBy=multi-user.target

--- a/components/centos/centos-openshift-setup/service_script/openshift_option
+++ b/components/centos/centos-openshift-setup/service_script/openshift_option
@@ -1,6 +1,6 @@
 # /etc/sysconfig/openshift_options
 
 # Modify these options if you want to change openshift route and hostname
-OPTIONS="-r cdk.vm -host 10.1.2.2"
-IMAGE="openshift/origin:latest"
+OPTIONS="-r adb.vm -host 10.1.2.2"
+IMAGE="openshift/origin:v1.1.1"
 DOCKER_REGISTRY="docker.io"

--- a/components/centos/centos-openshift-setup/service_script/openshift_option
+++ b/components/centos/centos-openshift-setup/service_script/openshift_option
@@ -1,0 +1,6 @@
+# /etc/sysconfig/openshift_options
+
+# Modify these options if you want to change openshift route and hostname
+OPTIONS="-r cdk.vm -host 10.1.2.2"
+IMAGE="openshift/origin:latest"
+DOCKER_REGISTRY="docker.io"

--- a/components/centos/centos-openshift-setup/service_script/openshift_provision
+++ b/components/centos/centos-openshift-setup/service_script/openshift_provision
@@ -9,8 +9,6 @@ export ORIGIN_DIR="/var/lib/origin"
 export OPENSHIFT_DIR=${ORIGIN_DIR}/openshift.local.config/master
 export KUBECONFIG=${OPENSHIFT_DIR}/admin.kubeconfig
 
-# The Docker registry from where we pull the OpenShift Enterprise Docker image
-echo "export KUBECONFIG=${OPENSHIFT_DIR}/admin.kubeconfig" > /etc/profile.d/kubeconf.sh
 
 function usage
 {
@@ -40,7 +38,7 @@ done
 echo "[INFO] Waiting for OpenShift sever to come up ..."
 for i in {1..6}
 do
-  curl -ksSf https://10.0.2.15:8443/api > /dev/null 2>&1
+  curl -ksSf https://127.0.0.1:8443/api > /dev/null 2>&1
   if [ $? -ne 0 ]; then
     echo "[INFO] ..."
     sleep 5
@@ -50,7 +48,7 @@ do
 done
 
 # Final check whether OpenShift is running
-curl -ksSf https://10.0.2.15:8443/api > /dev/null 2>&1
+curl -ksSf https://127.0.0.1:8443/api > /dev/null 2>&1
 if [ $? -ne 0 ]; then
   >&2 echo "[ERROR] OpenShift failed to start:"
   docker logs openshift

--- a/components/centos/centos-openshift-setup/service_script/openshift_provision
+++ b/components/centos/centos-openshift-setup/service_script/openshift_provision
@@ -9,6 +9,33 @@ export ORIGIN_DIR="/var/lib/origin"
 export OPENSHIFT_DIR=${ORIGIN_DIR}/openshift.local.config/master
 export KUBECONFIG=${OPENSHIFT_DIR}/admin.kubeconfig
 
+# The Docker registry from where we pull the OpenShift Enterprise Docker image
+echo "export KUBECONFIG=${OPENSHIFT_DIR}/admin.kubeconfig" > /etc/profile.d/kubeconf.sh
+
+function usage
+{
+    echo "usage: openshift_provision [[[-r route ] [-host hostname]] | [-h]]"
+}
+
+# Command line options
+
+while [ $# -gt 0 ]; do
+    case $1 in
+        -r | --route )          shift
+                                route=$1
+                                ;;
+        -host | --hostname )    shift
+                                host=$1
+                                ;;
+        -h | --help )           usage
+                                exit
+                                ;;
+        * )                     usage
+                                exit 1
+    esac
+    shift
+done
+
 # Give OpenShift time to start
 echo "[INFO] Waiting for OpenShift sever to come up ..."
 for i in {1..6}
@@ -110,7 +137,7 @@ fi
 if [ ! -f ${ORIGIN_DIR}/configured.user ]; then
   echo "[INFO] Creating 'test-admin' user and 'test' project ..."
   oadm policy add-role-to-user view test-admin --config=${OPENSHIFT_DIR}/admin.kubeconfig
-  oc login https://#{PUBLIC_ADDRESS}:8443 -u test-admin -p test \
+  oc login https://$host:8443 -u test-admin -p test \
         --certificate-authority=${OPENSHIFT_DIR}/ca.crt &>/dev/null
   oc new-project test --display-name="OpenShift 3 Sample" \
         --description="This is an example project to demonstrate OpenShift v3" &>/dev/null

--- a/components/centos/centos-openshift-setup/service_script/openshift_provision
+++ b/components/centos/centos-openshift-setup/service_script/openshift_provision
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+
+# Prepare, configure and start OpenShift
+
+set -o pipefail
+set -o nounset
+
+export ORIGIN_DIR="/var/lib/origin"
+export OPENSHIFT_DIR=${ORIGIN_DIR}/openshift.local.config/master
+export KUBECONFIG=${OPENSHIFT_DIR}/admin.kubeconfig
+
+# Give OpenShift time to start
+echo "[INFO] Waiting for OpenShift sever to come up ..."
+for i in {1..6}
+do
+  curl -ksSf https://10.0.2.15:8443/api > /dev/null 2>&1
+  if [ $? -ne 0 ]; then
+    echo "[INFO] ..."
+    sleep 5
+  else
+    break
+  fi
+done
+
+# Final check whether OpenShift is running
+curl -ksSf https://10.0.2.15:8443/api > /dev/null 2>&1
+if [ $? -ne 0 ]; then
+  >&2 echo "[ERROR] OpenShift failed to start:"
+  docker logs openshift
+  exit 1
+fi
+
+# Make sure kubeconfig is writable
+chmod go+r ${KUBECONFIG}
+
+# Create Docker Registry
+if [ ! -f ${ORIGIN_DIR}/configured.registry ]; then
+  echo "[INFO] Configuring Docker Registry"
+  oadm registry --create --credentials=${OPENSHIFT_DIR}/openshift-registry.kubeconfig || exit 1
+  oadm policy add-scc-to-group anyuid system:authenticated || exit 1
+  touch ${ORIGIN_DIR}/configured.registry
+fi
+
+# For router, we have to create service account first and then use it for router creation.
+if [ ! -f ${ORIGIN_DIR}/configured.router ]; then
+  echo "[INFO] Configuring HAProxy router"
+  echo '{"kind":"ServiceAccount","apiVersion":"v1","metadata":{"name":"router"}}' \
+    | oc create -f -
+  oc get scc privileged -o json \
+    | sed '/\"users\"/a \"system:serviceaccount:default:router\",'  \
+    | oc replace scc privileged -f -
+  oadm router --create \
+    --expose-metrics=true \
+    --credentials=${OPENSHIFT_DIR}/openshift-router.kubeconfig \
+    --service-account=router
+  touch ${ORIGIN_DIR}/configured.router
+
+  registry_host_name="hub.$(hostname)"
+  oc expose service docker-registry --hostname ${registry_host_name}
+fi
+
+# Installing templates into OpenShift
+if [ ! -f ${ORIGIN_DIR}/configured.templates ]; then
+  echo "[INFO] Installing OpenShift templates"
+
+  # TODO - These list must be verified and completed for a official release
+  # Currently templates are sources from three main repositories
+  # - openshift/origin
+  # - openshift/nodejs-ex
+  # - jboss-openshift/application-templates
+  ose_tag=ose-v1.1.0
+  template_list=(
+    # Image streams
+    https://raw.githubusercontent.com/openshift/origin/master/examples/image-streams/image-streams-rhel7.json
+    https://raw.githubusercontent.com/jboss-openshift/application-templates/${ose_tag}/jboss-image-streams.json
+    # DB templates
+    https://raw.githubusercontent.com/openshift/origin/master/examples/db-templates/mongodb-ephemeral-template.json
+    https://raw.githubusercontent.com/openshift/origin/master/examples/db-templates/mongodb-persistent-template.json
+    https://raw.githubusercontent.com/openshift/origin/master/examples/db-templates/mysql-ephemeral-template.json
+    https://raw.githubusercontent.com/openshift/origin/master/examples/db-templates/mysql-persistent-template.json
+    https://raw.githubusercontent.com/openshift/origin/master/examples/db-templates/postgresql-ephemeral-template.json
+    https://raw.githubusercontent.com/openshift/origin/master/examples/db-templates/postgresql-persistent-template.json
+    # Jenkins
+    https://raw.githubusercontent.com/openshift/origin/master/examples/jenkins/jenkins-ephemeral-template.json
+    https://raw.githubusercontent.com/openshift/origin/master/examples/jenkins/jenkins-persistent-template.json
+    # Node.js
+    https://raw.githubusercontent.com/openshift/nodejs-ex/master/openshift/templates/nodejs-mongodb.json
+    https://raw.githubusercontent.com/openshift/nodejs-ex/master/openshift/templates/nodejs.json
+    # EAP
+    https://raw.githubusercontent.com/jboss-openshift/application-templates/${ose_tag}/eap/eap64-amq-persistent-s2i.json
+    https://raw.githubusercontent.com/jboss-openshift/application-templates/${ose_tag}/eap/eap64-amq-s2i.json
+    https://raw.githubusercontent.com/jboss-openshift/application-templates/${ose_tag}/eap/eap64-basic-s2i.json
+    https://raw.githubusercontent.com/jboss-openshift/application-templates/${ose_tag}/eap/eap64-https-s2i.json
+    https://raw.githubusercontent.com/jboss-openshift/application-templates/${ose_tag}/eap/eap64-mongodb-persistent-s2i.json
+    https://raw.githubusercontent.com/jboss-openshift/application-templates/${ose_tag}/eap/eap64-mongodb-s2i.json
+    https://raw.githubusercontent.com/jboss-openshift/application-templates/${ose_tag}/eap/eap64-mysql-persistent-s2i.json
+    https://raw.githubusercontent.com/jboss-openshift/application-templates/${ose_tag}/eap/eap64-mysql-s2i.json
+    https://raw.githubusercontent.com/jboss-openshift/application-templates/${ose_tag}/eap/eap64-postgresql-persistent-s2i.json
+    https://raw.githubusercontent.com/jboss-openshift/application-templates/${ose_tag}/eap/eap64-postgresql-s2i.json
+  )
+
+  for template in ${template_list[@]}; do
+    echo "[INFO] Importing template ${template}"
+    oc create -f $template -n openshift >/dev/null
+  done
+  touch ${ORIGIN_DIR}/configured.templates
+fi
+
+# Configuring a test-admin user which can view the detault namespace
+if [ ! -f ${ORIGIN_DIR}/configured.user ]; then
+  echo "[INFO] Creating 'test-admin' user and 'test' project ..."
+  oadm policy add-role-to-user view test-admin --config=${OPENSHIFT_DIR}/admin.kubeconfig
+  oc login https://#{PUBLIC_ADDRESS}:8443 -u test-admin -p test \
+        --certificate-authority=${OPENSHIFT_DIR}/ca.crt &>/dev/null
+  oc new-project test --display-name="OpenShift 3 Sample" \
+        --description="This is an example project to demonstrate OpenShift v3" &>/dev/null
+  sudo touch ${ORIGIN_DIR}/configured.user
+fi

--- a/components/centos/centos-openshift-setup/service_script/run.sh
+++ b/components/centos/centos-openshift-setup/service_script/run.sh
@@ -1,0 +1,11 @@
+if [ $(whoami) != "root" ]; then
+   echo "Try with sudo or root user"
+   exit 1
+fi
+
+curl -sL https://raw.githubusercontent.com/projectatomic/adb-atomic-developer-bundle/master/components/centos/centos-openshift-setup/service_script/openshift --output /opt/adb/openshift
+curl -sL https://raw.githubusercontent.com/projectatomic/adb-atomic-developer-bundle/master/components/centos/centos-openshift-setup/service_script/openshift_provision --output /opt/adb/openshift_provision
+curl -sL https://raw.githubusercontent.com/projectatomic/adb-atomic-developer-bundle/master/components/centos/centos-openshift-setup/service_script/openshift.service --output /usr/lib/systemd/system/openshift.service
+curl -sL https://raw.githubusercontent.com/projectatomic/adb-atomic-developer-bundle/master/components/centos/centos-openshift-setup/service_script/openshift_option --output /etc/sysconfig/openshift_option
+chmod +x /opt/adb/openshift /opt/adb/openshift_provision
+systemctl daemon-reload


### PR DESCRIPTION
This is address to use openshift as a service. Currently required origin/ose images should be available on target. To test it it contain `run.sh` which will place file in place and make sure you changes `openshift_option` according to your setup.
