### PR TITLE
Fix #222 httpd-tools package should be present in kickstart file

### DIFF
--- a/build_tools/kickstarts/centos-7-adb-vagrant.ks
+++ b/build_tools/kickstarts/centos-7-adb-vagrant.ks
@@ -45,6 +45,7 @@ nfs-utils
 PyYAML
 libyaml-devel
 tuned
+httpd-tools
 
 %end
 


### PR DESCRIPTION
This is required for openshift auth part if we are going to use `HTPasswdPasswordIdentityProvider` for identity.
