### PR TITLE
Set ip address for Marathon and Mesos-slave before installing packages.

### DIFF
--- a/components/centos/centos-mesos-marathon-singlenode-setup/Vagrantfile
+++ b/components/centos/centos-mesos-marathon-singlenode-setup/Vagrantfile
@@ -21,10 +21,7 @@ Vagrant.configure("2") do |config|
     config.vm.provision "shell", inline: <<-SHELL
         sudo yum -y install epel-release
         sudo yum -y install ansible
-        sudo ansible-playbook /vagrant/provisioning/playbook.yml
-        sudo mkdir -p /etc/marathon/conf
-        sudo sh -c "echo \"#{IP_ADDRESS}\" > /etc/marathon/conf/hostname"
-        sudo sh -c "echo \"#{IP_ADDRESS}\" > /etc/mesos-slave/ip"
+        sudo ansible-playbook -e ip_address=#{IP_ADDRESS} /vagrant/provisioning/playbook.yml
     SHELL
 
     config.vm.network "private_network", ip: "#{IP_ADDRESS}"

--- a/components/centos/centos-mesos-marathon-singlenode-setup/provisioning/playbook.yml
+++ b/components/centos/centos-mesos-marathon-singlenode-setup/provisioning/playbook.yml
@@ -2,6 +2,26 @@
   sudo: yes
   connection: local
   tasks:
+
+          # Packages start services, this is why we need to configure it before install
+          - name: Create dir for Mesos Slave config
+            file: path=/etc/{{ item }} state=directory
+            with_items:
+                - marathon/conf
+                - mesos-slave
+
+          - name: Configure IP address for mesos-slave
+            shell: echo '{{ ip_address }}' > /etc/mesos-slave/ip
+
+          - name: Increase timeout to account for docker pull delay
+            shell: echo '5mins' > /etc/mesos-slave/executor_registration_timeout
+
+          - name: Add docker containerizer
+            shell: echo 'docker,mesos' > /etc/mesos-slave/containerizers
+
+          - name: Configure IP address for Marathon
+            shell: echo '{{ ip_address }}' > /etc/marathon/conf/hostname
+
           - name: Install Mesosphere repository
             yum: name=http://repos.mesosphere.com/el/7/noarch/RPMS/mesosphere-el-repo-7-3.noarch.rpm state=present
 
@@ -13,7 +33,6 @@
                 - marathon
                 - docker
                 - git
-            register: result
 
           - name: Starting zookeeper, mesos, marathon, docker
             service: name={{item}} state=started enabled=yes
@@ -24,13 +43,4 @@
                 - marathon
                 - docker
 
-          - name: Add docker containerizer
-            shell: echo 'docker,mesos' > /etc/mesos-slave/containerizers
-            when: result|success
 
-          - name: Increase timeout to account for docker pull delay
-            shell: echo '5mins' > /etc/mesos-slave/executor_registration_timeout
-            when: result|success
-
-          - name: Restart mesos-slave
-            service: name=mesos-slave state=restarted


### PR DESCRIPTION
Packages are starting service, if we do config change after package is
installed we need that restart services. If we create configs before
installing pkgs, we don't have to restart them afterwards.
