### PR TITLE
Forcefully tag an already tagged docker image

### DIFF
--- a/components/centos/centos-openshift-setup/Vagrantfile
+++ b/components/centos/centos-openshift-setup/Vagrantfile
@@ -69,7 +69,7 @@ Vagrant.configure(2) do |config|
     docker inspect openshift/origin &>/dev/null && exit 0
     echo "[INFO] Pull the #{ORIGIN_IMAGE_NAME} Docker image ..."
     docker pull #{ORIGIN_IMAGE_NAME}
-    docker tag #{DOCKER_REGISTRY}/#{ORIGIN_IMAGE_NAME} #{ORIGIN_IMAGE_NAME}
+    docker tag -f #{DOCKER_REGISTRY}/#{ORIGIN_IMAGE_NAME} #{ORIGIN_IMAGE_NAME}
   SHELL
 
   config.vm.provision "shell", inline: <<-SHELL


### PR DESCRIPTION
When openshift image was pulled and tagged with specific tag
if the image is already present and if tried taggig with same
tag docker gives an error, so adding -f forefully tags the image
thereby keeping the Vagrant provision run flawlessly.

Fixes issue #233 
