### PR TITLE
Support openstack provider in vagrantfiles

### DIFF
--- a/build_tools/build_scripts/do_vagrant_cbs.sh
+++ b/build_tools/build_scripts/do_vagrant_cbs.sh
@@ -19,4 +19,3 @@ koji -p cbs image-build \
   --scratch \
   --nowait \
   --disk-size=40
-

--- a/components/centos/centos-docker-base-setup/Vagrantfile
+++ b/components/centos/centos-docker-base-setup/Vagrantfile
@@ -28,4 +28,23 @@ Vagrant.configure(2) do |config|
     vbox.customize ["modifyvm", :id, "--ioapic", "on"]
   end
 
+  config.vm.provider "openstack" do |os|
+      # Specify OpenStack authentication information
+      os.openstack_auth_url = ENV['OS_AUTH_URL']
+      os.tenant_name = ENV['OS_TENANT_NAME']
+      os.username = ENV['OS_USERNAME']
+      os.password = ENV['OS_PASSWORD']
+
+      # Specify instance information
+      os.server_name = ENV['OS_INSTANCE']
+      os.flavor = ENV['OS_FLAVOR']
+      os.image = ENV['OS_IMAGE']
+      os.floating_ip_pool = ENV['OS_FLOATING_IP_POOL']
+
+      os.security_groups = ['default', ENV['OS_SECURITY_GROUP']]
+      os.keypair_name = ENV['OS_KEYPAIR_NAME']
+      config.ssh.private_key_path = ENV['OS_PRIVATE_KEYPATH']
+      config.ssh.username = 'vagrant'
+    end
+
 end

--- a/components/centos/centos-k8s-singlenode-setup/Vagrantfile
+++ b/components/centos/centos-k8s-singlenode-setup/Vagrantfile
@@ -22,6 +22,25 @@ Vagrant.configure(2) do |config|
   # Setup a DHCP based private network
   config.vm.network "private_network", type: "dhcp"
 
+  config.vm.provider "openstack" do |os|
+      # Specify OpenStack authentication information
+      os.openstack_auth_url = ENV['OS_AUTH_URL']
+      os.tenant_name = ENV['OS_TENANT_NAME']
+      os.username = ENV['OS_USERNAME']
+      os.password = ENV['OS_PASSWORD']
+
+      # Specify instance information
+      os.server_name = ENV['OS_INSTANCE']
+      os.flavor = ENV['OS_FLAVOR']
+      os.image = ENV['OS_IMAGE']
+      os.floating_ip_pool = ENV['OS_FLOATING_IP_POOL']
+
+      os.security_groups = ['default', ENV['OS_SECURITY_GROUP']]
+      os.keypair_name = ENV['OS_KEYPAIR_NAME']
+      config.ssh.private_key_path = ENV['OS_PRIVATE_KEYPATH']
+      config.ssh.username = 'vagrant'
+    end
+
   config.vm.provision "shell", inline: <<-SHELL
      sudo mkdir -p /etc/pki/kube-apiserver/
      sudo openssl genrsa -out /etc/pki/kube-apiserver/serviceaccount.key 2048

--- a/components/centos/centos-mesos-marathon-singlenode-setup/Vagrantfile
+++ b/components/centos/centos-mesos-marathon-singlenode-setup/Vagrantfile
@@ -17,7 +17,26 @@ Vagrant.configure("2") do |config|
         v.memory = 2048
         v.cpus = 2
     end
-    
+
+    config.vm.provider "openstack" do |os|
+        # Specify OpenStack authentication information
+        os.openstack_auth_url = ENV['OS_AUTH_URL']
+        os.tenant_name = ENV['OS_TENANT_NAME']
+        os.username = ENV['OS_USERNAME']
+        os.password = ENV['OS_PASSWORD']
+
+        # Specify instance information
+        os.server_name = ENV['OS_INSTANCE']
+        os.flavor = ENV['OS_FLAVOR']
+        os.image = ENV['OS_IMAGE']
+        os.floating_ip_pool = ENV['OS_FLOATING_IP_POOL']
+
+        os.security_groups = ['default', ENV['OS_SECURITY_GROUP']]
+        os.keypair_name = ENV['OS_KEYPAIR_NAME']
+        config.ssh.private_key_path = ENV['OS_PRIVATE_KEYPATH']
+        config.ssh.username = 'vagrant'
+      end
+
     config.vm.provision "shell", inline: <<-SHELL
         sudo yum -y install epel-release
         sudo yum -y install ansible

--- a/components/centos/centos-openshift-setup/Vagrantfile
+++ b/components/centos/centos-openshift-setup/Vagrantfile
@@ -46,6 +46,25 @@ Vagrant.configure(2) do |config|
     v.cpus   = 2
   end
 
+  config.vm.provider "openstack" do |os|
+      # Specify OpenStack authentication information
+      os.openstack_auth_url = ENV['OS_AUTH_URL']
+      os.tenant_name = ENV['OS_TENANT_NAME']
+      os.username = ENV['OS_USERNAME']
+      os.password = ENV['OS_PASSWORD']
+
+      # Specify instance information
+      os.server_name = ENV['OS_INSTANCE']
+      os.flavor = ENV['OS_FLAVOR']
+      os.image = ENV['OS_IMAGE']
+      os.floating_ip_pool = ENV['OS_FLOATING_IP_POOL']
+
+      os.security_groups = ['default', ENV['OS_SECURITY_GROUP']]
+      os.keypair_name = ENV['OS_KEYPAIR_NAME']
+      config.ssh.private_key_path = ENV['OS_PRIVATE_KEYPATH']
+      config.ssh.username = 'vagrant'
+    end
+
   config.vm.network "private_network", ip: "#{PUBLIC_ADDRESS}"
 
 


### PR DESCRIPTION
This PR enables provisioning VMs on Openstack using `vagrant-openstack-provider` plugin.
As a result we can setup a simple CI to verify changes and add documentation on how to run ADB on TryStack.
