### PR TITLE
Fix #250: Configures kube-apiserver to run on 0.0.0.0

### DIFF
--- a/build_tools/kickstarts/centos-7-adb-vagrant.ks
+++ b/build_tools/kickstarts/centos-7-adb-vagrant.ks
@@ -100,6 +100,9 @@ LimitNOFILE=65536
 WantedBy=multi-user.target
 EOF
 
+# Fix for issue #250
+sed -i.back '/KUBE_API_ADDRESS=*/c\KUBE_API_ADDRESS="--address=0.0.0.0"' /etc/kubernetes/apiserver
+
 mv kube-apiserver.service /etc/systemd/system/
 systemctl daemon-reload
 

--- a/build_tools/kickstarts/rhel-7-kubernetes-vagrant.ks
+++ b/build_tools/kickstarts/rhel-7-kubernetes-vagrant.ks
@@ -82,6 +82,10 @@ WantedBy=multi-user.target
 EOF
 
 mv kube-apiserver.service /etc/systemd/system/
+
+# Fix for issue #250
+sed -i.back '/KUBE_API_ADDRESS=*/c\KUBE_API_ADDRESS="--address=0.0.0.0"' /etc/kubernetes/apiserver
+
 systemctl daemon-reload
 
 # set tuned profile to force virtual-guest


### PR DESCRIPTION
Fixes #250 : 
 This patch configures the kubernetes apiserver configurations to
 run on 0.0.0.0 instead of 127.0.0.1 so that external kubectl
 clients can connect to it.
