### PR TITLE
Removing the sed commands because these are not required anymore

### DIFF
--- a/build_tools/kickstarts/centos-7-adb-vagrant.ks
+++ b/build_tools/kickstarts/centos-7-adb-vagrant.ks
@@ -53,10 +53,6 @@ centos-release-adb
 
 %post
 
-# Needed to allow this to boot a second time with an unknown MAC
-sed -i "/HWADDR/d" /etc/sysconfig/network-scripts/ifcfg-eth*
-sed -i "/UUID/d" /etc/sysconfig/network-scripts/ifcfg-eth*
-
 # Add adb version info to consumed by vagrant-service-manager plugin
 # https://github.com/projectatomic/adb-atomic-developer-bundle/issues/183
 echo "VARIANT=\"Atomic Developer Bundle (ADB)\"" >> /etc/os-release


### PR DESCRIPTION
As we are overwriting the eth0 interface in the kickstartfile

Signed-off-by: Lalatendu Mohanty lmohanty@redhat.com
