### PR TITLE
Fix-256: Add check for vagrant-registration plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## Unreleased
+- Fix-256: Add check for vagrant-registration plugin @budhrg
+- Refactored code for checking required plugins for CentOS files @budhrg
 - Update README for RHEL component @praveenkumar
 
 ## v1.8.0 Apr 5, 2016

--- a/components/centos/centos-docker-base-setup/Vagrantfile
+++ b/components/centos/centos-docker-base-setup/Vagrantfile
@@ -1,11 +1,18 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
 
-#Vagrant file for libvirt/kvm and virtualbox provider
+# Vagrant file for libvirt/kvm and virtualbox provider
+REQUIRED_PLUGINS = %w(vagrant-service-manager)
+errors = []
 
-# check if plugin is installed on system
-unless Vagrant.has_plugin?("vagrant-service-manager")
-  raise "vagrant-service-manager plugin is not installed, run `vagrant plugin install vagrant-service-manager` to install the plugin."
+def message(name)
+  "#{name} plugin is not installed, run `vagrant plugin install #{name}` to install it."
+end
+# Validate and collect error message if plugin is not installed
+REQUIRED_PLUGINS.each { |plugin| errors << message(plugin) unless Vagrant.has_plugin?(plugin) }
+unless errors.empty?
+  msg = errors.size > 1 ? "Errors: \n* #{errors.join("\n* ")}" : "Error: #{errors.first}"
+  fail Vagrant::Errors::VagrantError.new, msg
 end
 
 Vagrant.configure(2) do |config|

--- a/components/centos/centos-k8s-singlenode-setup/Vagrantfile
+++ b/components/centos/centos-k8s-singlenode-setup/Vagrantfile
@@ -1,11 +1,18 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
 
-#check if vagrant-service-manager is installed on system
-unless Vagrant.has_plugin?("vagrant-service-manager")
-  raise "vagrant-service-manager plugin is not installed, run `vagrant plugin install vagrant-service-manager` to install the plugin."
-end
+REQUIRED_PLUGINS = %w(vagrant-service-manager)
+errors = []
 
+def message(name)
+  "#{name} plugin is not installed, run `vagrant plugin install #{name}` to install it."
+end
+# Validate and collect error message if plugin is not installed
+REQUIRED_PLUGINS.each { |plugin| errors << message(plugin) unless Vagrant.has_plugin?(plugin) }
+unless errors.empty?
+  msg = errors.size > 1 ? "Errors: \n* #{errors.join("\n* ")}" : "Error: #{errors.first}"
+  fail Vagrant::Errors::VagrantError.new, msg
+end
 
 # Vagrantfile for single node k8s setup
 Vagrant.configure(2) do |config|

--- a/components/centos/centos-mesos-marathon-singlenode-setup/Vagrantfile
+++ b/components/centos/centos-mesos-marathon-singlenode-setup/Vagrantfile
@@ -4,9 +4,17 @@
 
 IP_ADDRESS="10.2.2.2"
 
-#check if vagrant-service-manager is installed on system
-unless Vagrant.has_plugin?("vagrant-service-manager")
-  raise "vagrant-service-manager plugin is not installed, run `vagrant plugin install vagrant-service-manager` to install the plugin."
+REQUIRED_PLUGINS = %w(vagrant-service-manager)
+errors = []
+
+def message(name)
+  "#{name} plugin is not installed, run `vagrant plugin install #{name}` to install it."
+end
+# Validate and collect error message if plugin is not installed
+REQUIRED_PLUGINS.each { |plugin| errors << message(plugin) unless Vagrant.has_plugin?(plugin) }
+unless errors.empty?
+  msg = errors.size > 1 ? "Errors: \n* #{errors.join("\n* ")}" : "Error: #{errors.first}"
+  fail Vagrant::Errors::VagrantError.new, msg
 end
 
 Vagrant.configure("2") do |config|

--- a/components/centos/centos-openshift-setup/Vagrantfile
+++ b/components/centos/centos-openshift-setup/Vagrantfile
@@ -13,9 +13,17 @@ IMAGE_TAG="v1.1.1"
 PUBLIC_ADDRESS="10.1.2.2"
 PUBLIC_HOST="adb.cluster.io"
 
-#check if vagrant-service-manager is installed on system
-unless Vagrant.has_plugin?("vagrant-service-manager")
-  raise "vagrant-service-manager plugin is not installed, run `vagrant plugin install vagrant-service-manager` to install the plugin."
+REQUIRED_PLUGINS = %w(vagrant-service-manager)
+errors = []
+
+def message(name)
+  "#{name} plugin is not installed, run `vagrant plugin install #{name}` to install it."
+end
+# Validate and collect error message if plugin is not installed
+REQUIRED_PLUGINS.each { |plugin| errors << message(plugin) unless Vagrant.has_plugin?(plugin) }
+unless errors.empty?
+  msg = errors.size > 1 ? "Errors: \n* #{errors.join("\n* ")}" : "Error: #{errors.first}"
+  fail Vagrant::Errors::VagrantError.new, msg
 end
 
 # The following steps are executed to provision OpenShift Origin:

--- a/components/rhel/misc/rhel-k8s-singlenode-setup/Vagrantfile
+++ b/components/rhel/misc/rhel-k8s-singlenode-setup/Vagrantfile
@@ -1,5 +1,17 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
+REQUIRED_PLUGINS = %w(vagrant-service-manager  vagrant-registration)
+errors = []
+
+def message(name)
+  "#{name} plugin is not installed, run `vagrant plugin install #{name}` to install it."
+end
+# Validate and collect error message if plugin is not installed
+REQUIRED_PLUGINS.each { |plugin| errors << message(plugin) unless Vagrant.has_plugin?(plugin) }
+unless errors.empty?
+  msg = errors.size > 1 ? "Errors: \n* #{errors.join("\n* ")}" : "Error: #{errors.first}"
+  fail Vagrant::Errors::VagrantError.new, msg
+end
 
 # Vagrantfile for single node k8s setup
 Vagrant.configure(2) do |config|

--- a/components/rhel/rhel-ose/Vagrantfile
+++ b/components/rhel/rhel-ose/Vagrantfile
@@ -12,11 +12,17 @@ VM_MEMORY = ENV['VM_MEMORY'] || 3072
 
 # Validate required plugins
 REQUIRED_PLUGINS = %w(vagrant-service-manager vagrant-registration)
-message = ->(name) { "#{name} plugin is not installed, run `vagrant plugin install #{name}` to install it." }
 errors = []
-REQUIRED_PLUGINS.each {|plugin| errors << message.call(plugin) unless Vagrant.has_plugin?(plugin) }
-msg = errors.size > 1 ? "Errors: \n* #{errors.join("\n* ")}" : "Error: #{errors.first}"
-raise Vagrant::Errors::VagrantError.new, msg unless errors.size == 0
+
+def message(name)
+  "#{name} plugin is not installed, run `vagrant plugin install #{name}` to install it."
+end
+# Validate and collect error message if plugin is not installed
+REQUIRED_PLUGINS.each { |plugin| errors << message(plugin) unless Vagrant.has_plugin?(plugin) }
+unless errors.empty?
+  msg = errors.size > 1 ? "Errors: \n* #{errors.join("\n* ")}" : "Error: #{errors.first}"
+  fail Vagrant::Errors::VagrantError.new, msg
+end
 
 Vagrant.configure(2) do |config|
   config.vm.box = "cdkv2"


### PR DESCRIPTION
Fix #256 
- Also scale up to check existence of multiple plugins
- Update "REQUIRED_PLUGINS" to add new required plugins
- For multiple errors it list as:
  - Error message one
  - Error message two
  - ... many more

Eg:
Now error messages:
Single Error:

```
Error: vagrant-registration plugin is not installed, run `vagrant plugin install vagrant-registration` to install it.
```

Multiple Error:

```
Errors: 
* vagrant-service-manager plugin is not installed, run `vagrant plugin install vagrant-service-manager` to install it.
* vagrant-registration plugin is not installed, run `vagrant plugin install vagrant-registration` to install it.
```

Putting `Error(s)` was my choice. If it is doesn't seem correct, let me know.
