### PR TITLE
Remove docker-registry from installed packages

### DIFF
--- a/build_tools/kickstarts/centos-7-adb-vagrant.ks
+++ b/build_tools/kickstarts/centos-7-adb-vagrant.ks
@@ -40,7 +40,6 @@ flannel
 bash-completion
 man-pages
 atomic
-docker-registry
 nfs-utils
 PyYAML
 libyaml-devel


### PR DESCRIPTION
#274  Better to remove deprecated version of docker-registry and then we will see what way we should handle this issue.
