### PR TITLE
Install libvirt-devel before installing vagrant-service-manager plugin

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -130,6 +130,8 @@ Detailed `installation instructions`_ are available.
 
 3. Install the `vagrant-service-manager`_ Vagrant plugin:
 
+   ``sudo dnf install libvirt-devel``
+   
    ``vagrant plugin install vagrant-service-manager``
 
 4. Download the latest ADB from `atlas.hashicorp.com`_.  This can be


### PR DESCRIPTION
I was getting following error when installing the plugin:

```
$ vagrant plugin install vagrant-service-manager
Installing the 'vagrant-service-manager' plugin. This can take a few minutes...
Bundler, the underlying system Vagrant uses to install plugins,
reported an error. The error is shown below. These errors are usually
caused by misconfigured plugin installations or transient network
issues. The error from Bundler is:

An error occurred while installing ruby-libvirt (0.6.0), and Bundler cannot continue.
Make sure that `gem install ruby-libvirt -v '0.6.0'` succeeds before bundling.

Gem::Ext::BuildError: ERROR: Failed to build gem native extension.

    /usr/bin/ruby -r ./siteconf20160406-25281-5fb543.rb extconf.rb 
*** extconf.rb failed ***
Could not create Makefile due to some reason, probably lack of necessary
libraries and/or headers.  Check the mkmf.log file for more details.  You may
need configuration options.

Provided configuration options:
    --with-opt-dir
    --without-opt-dir
    --with-opt-include
    --without-opt-include=${opt-dir}/include
    --with-opt-lib
    --without-opt-lib=${opt-dir}/lib64
    --with-make-prog
    --without-make-prog
    --srcdir=.
    --curdir
    --ruby=/usr/bin/$(RUBY_BASE_NAME)
    --with-libvirt-include
    --without-libvirt-include
    --with-libvirt-lib
    --without-libvirt-lib
    --with-libvirt-config
    --without-libvirt-config
    --with-pkg-config
    --without-pkg-config
extconf.rb:73:in `<main>': libvirt library not found in default locations (RuntimeError)

extconf failed, exit code 1

Gem files will remain installed in /home/saleem/.vagrant.d/gems/gems/ruby-libvirt-0.6.0 for inspection.
Results logged to /home/saleem/.vagrant.d/gems/extensions/x86_64-linux/ruby-libvirt-0.6.0/gem_make.out
```

Updated readme instructions  in this PR.
