### PR TITLE
Suppress logs of openssl genrsa on Vagrant up for Kubernetes 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unreleased
+- Fix #345: Suppress logs of openssl genrsa on Vagrant up for Kubernetes @budhrg
 - Fix #342: Use systemctl to start openshift service in CDK OSE Vagrantfile @LalatenduMohanty
 - Fix #334: Disables openshift service for CDK k8s Vagrantfile @navidshaikh
 - Fix-256: Add check for vagrant-registration plugin @budhrg

--- a/components/centos/centos-k8s-singlenode-setup/Vagrantfile
+++ b/components/centos/centos-k8s-singlenode-setup/Vagrantfile
@@ -56,7 +56,7 @@ Vagrant.configure(2) do |config|
 
   config.vm.provision "shell", inline: <<-SHELL
     sudo mkdir -p /etc/pki/kube-apiserver/
-    sudo openssl genrsa -out /etc/pki/kube-apiserver/serviceaccount.key 2048
+    sudo openssl genrsa -out /etc/pki/kube-apiserver/serviceaccount.key 2048 > /dev/null 2>&1
     sudo sed -i.back '/KUBE_API_ARGS=*/c\KUBE_API_ARGS="--service_account_key_file=/etc/pki/kube-apiserver/serviceaccount.key"' /etc/kubernetes/apiserver
     sudo sed -i.back '/KUBE_CONTROLLER_MANAGER_ARGS=*/c\KUBE_CONTROLLER_MANAGER_ARGS="--service_account_private_key_file=/etc/pki/kube-apiserver/serviceaccount.key"' /etc/kubernetes/controller-manager
 

--- a/components/rhel/misc/rhel-k8s-singlenode-setup/Vagrantfile
+++ b/components/rhel/misc/rhel-k8s-singlenode-setup/Vagrantfile
@@ -40,7 +40,7 @@ Vagrant.configure(2) do |config|
 
   config.vm.provision "shell", inline: <<-SHELL
      sudo mkdir -p /etc/pki/kube-apiserver/
-     sudo openssl genrsa -out /etc/pki/kube-apiserver/serviceaccount.key 2048
+     sudo openssl genrsa -out /etc/pki/kube-apiserver/serviceaccount.key 2048 > /dev/null 2>&1
      sudo sed -i.back '/KUBE_API_ARGS=*/c\KUBE_API_ARGS="--service_account_key_file=/etc/pki/kube-apiserver/serviceaccount.key"' /etc/kubernetes/apiserver
      sudo sed -i.back '/KUBE_CONTROLLER_MANAGER_ARGS=*/c\KUBE_CONTROLLER_MANAGER_ARGS="--service_account_private_key_file=/etc/pki/kube-apiserver/serviceaccount.key"' /etc/kubernetes/controller-manager
 


### PR DESCRIPTION
Fix #345 

Now logs below:

```
➜ $  vagrant up --provider virtualbox
Bringing machine 'default' up with 'virtualbox' provider...
==> default: Importing base box 'projectatomic/adb'...
==> default: Matching MAC address for NAT networking...
==> default: Checking if box 'projectatomic/adb' is up to date...
==> default: Setting the name of the VM: vagrant-service-manager_default_1460545323510_46644
==> default: Clearing any previously set network interfaces...
==> default: Preparing network interfaces based on configuration...
    default: Adapter 1: nat
    default: Adapter 2: hostonly
==> default: Forwarding ports...
    default: 22 (guest) => 2222 (host) (adapter 1)
==> default: Running 'pre-boot' VM customizations...
==> default: Booting VM...
==> default: Waiting for machine to boot. This may take a few minutes...
    default: SSH address: 127.0.0.1:2222
    default: SSH username: vagrant
    default: SSH auth method: private key
    default: 
    default: Vagrant insecure key detected. Vagrant will automatically replace
    default: this with a newly generated keypair for better security.
    default: 
    default: Inserting generated public key within guest...
    default: Removing insecure key from the guest if it's present...
    default: Key inserted! Disconnecting and reconnecting using new SSH key...
==> default: Machine booted and ready!
==> default: Checking for guest additions in VM...
    default: No guest additions were detected on the base box for this VM! Guest
    default: additions are required for forwarded ports, shared folders, host only
    default: networking, and more. If SSH fails on this machine, please install
    default: the guest additions and repackage the box to continue.
    default: 
    default: This is not an error message; everything may continue to work properly,
    default: in which case you may ignore this message.
==> default: Configuring and enabling network interfaces...
==> default: Copying TLS certificates to /home/budhram/redhat/vagrant-service-manager/.vagrant/machines/default/virtualbox/docker
==> default: Rsyncing folder: /home/budhram/redhat/vagrant-service-manager/ => /vagrant
==> default: Running provisioner: shell...
    default: Running: inline script
==> default: setup master
==> default:   enable etcd
==> default: Created symlink from /etc/systemd/system/multi-user.target.wants/etcd.service to /usr/lib/systemd/system/etcd.service.
==> default:   start etcd
==> default:   enable kube-apiserver
==> default: Created symlink from /etc/systemd/system/multi-user.target.wants/kube-apiserver.service to /etc/systemd/system/kube-apiserver.service.
==> default:   start kube-apiserver
==> default:   enable kube-controller-manager
==> default: Created symlink from /etc/systemd/system/multi-user.target.wants/kube-controller-manager.service to /usr/lib/systemd/system/kube-controller-manager.service.
==> default:   start kube-controller-manager
==> default:   enable kube-scheduler
==> default: Created symlink from /etc/systemd/system/multi-user.target.wants/kube-scheduler.service to /usr/lib/systemd/system/kube-scheduler.service.
==> default:   start kube-scheduler
==> default: setup nodes
==> default:   enable kube-proxy
==> default: Created symlink from /etc/systemd/system/multi-user.target.wants/kube-proxy.service to /usr/lib/systemd/system/kube-proxy.service.
==> default:   start kube-proxy
==> default:   enable kubelet
==> default: Created symlink from /etc/systemd/system/multi-user.target.wants/kubelet.service to /usr/lib/systemd/system/kubelet.service.
==> default:   start kubelet
==> default:   restart docker
```
