### PR TITLE
rhel-k8s Vagrantfile: fix in getting credentials

### DIFF
--- a/components/rhel/misc/rhel-k8s-singlenode-setup/Vagrantfile
+++ b/components/rhel/misc/rhel-k8s-singlenode-setup/Vagrantfile
@@ -17,8 +17,10 @@ end
 Vagrant.configure(2) do |config|
   config.vm.box = "cdkv2"
 
-  config.registration.username = ENV['SUB_USERNAME']
-  config.registration.password = ENV['SUB_PASSWORD']
+  if ENV.has_key?('SUB_USERNAME') && ENV.has_key?('SUB_PASSWORD')
+    config.registration.username = ENV['SUB_USERNAME']
+    config.registration.password = ENV['SUB_PASSWORD']
+  end
 
   config.vm.provider "libvirt" do |libvirt, override|
     libvirt.driver = "kvm"


### PR DESCRIPTION
use env variables only if set,
otherwise they can be in user's general Vagrantfile, which wasn't working
Fix #348
