### PR TITLE
Fix #103 'Cannot change locale (UTF-8)' on vagrant ssh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unreleased
+- Fix #103: build_tools/kickstarts/rhel-7-cdk-vagrant.ks @praveenkumar
 - Fix #345: Suppress logs of openssl genrsa on Vagrant up for Kubernetes @budhrg
 - Fix #342: Use systemctl to start openshift service in CDK OSE Vagrantfile @LalatenduMohanty
 - Fix #334: Disables openshift service for CDK k8s Vagrantfile @navidshaikh

--- a/build_tools/kickstarts/centos-7-adb-vagrant.ks
+++ b/build_tools/kickstarts/centos-7-adb-vagrant.ks
@@ -77,6 +77,9 @@ tuned-adm profile virtual-guest
 echo "%vagrant ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers.d/vagrant
 sed -i "s/^.*requiretty/#Defaults requiretty/" /etc/sudoers
 
+# Fix #103 (https://github.com/projectatomic/adb-atomic-developer-bundle/issues/103)
+echo "LC_ALL=en_US.utf-8" >> /etc/locale.conf
+
 # Fix for #128 (https://github.com/projectatomic/adb-atomic-developer-bundle/issues/128)
 cat > /etc/sysconfig/network-scripts/ifcfg-eth0 << EOF
 DEVICE="eth0"

--- a/build_tools/kickstarts/rhel-7-cdk-vagrant.ks
+++ b/build_tools/kickstarts/rhel-7-cdk-vagrant.ks
@@ -109,6 +109,9 @@ tuned-adm profile virtual-guest
 echo "%vagrant ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers.d/vagrant
 sed -i "s/^.*requiretty/#Defaults requiretty/" /etc/sudoers
 
+# Fix #103 (https://github.com/projectatomic/adb-atomic-developer-bundle/issues/103)
+echo "LC_ALL=en_US.utf-8" >> /etc/locale.conf
+
 #Fix for issue #128 upstrem ADB
 # VM won't start consistenly and abort startup with a timeout #128
 cat > /etc/sysconfig/network-scripts/ifcfg-eth0 << EOF


### PR DESCRIPTION
This patch will fix for `vagrant ssh` on OS X with VirtualBox provider throws following warning

```
$ vagrant ssh
bash: warning: setlocale: LC_CTYPE: cannot change locale (UTF-8): No such file or directory
```
