### PR TITLE
Removing the workaround of downgrading python-docker-py. Fixes #356

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unreleased
+- Remove the workaround for downgrading python-docker-py @LalatenduMohanty
 - Update os-release to 2.0.0 @LalatenduMohanty
 - Fix #103: build_tools/kickstarts/rhel-7-cdk-vagrant.ks @praveenkumar
 - Fix #345: Suppress logs of openssl genrsa on Vagrant up for Kubernetes @budhrg

--- a/build_tools/kickstarts/centos-7-adb-vagrant.ks
+++ b/build_tools/kickstarts/centos-7-adb-vagrant.ks
@@ -52,10 +52,6 @@ fuse-sshfs
 
 %post
 
-#downgrade python-docker-py
-#Workaround for https://github.com/projectatomic/adb-atomic-developer-bundle/issues/279#issuecomment-194110557
-yum downgrade python-docker-py -y
-
 # Add adb version info to consumed by vagrant-service-manager plugin
 # https://github.com/projectatomic/adb-atomic-developer-bundle/issues/183
 echo "VARIANT=\"Atomic Developer Bundle (ADB)\"" >> /etc/os-release


### PR DESCRIPTION
As the base distro has python-docker-py-1.7.2 and it works with atomic CLI
and on http://mirror.centos.org/centos-7/7/atomic/x86_64/adb/ we have
python-docker-py-1.7.0.0-1.

Previous discussion https://github.com/projectatomic/adb-atomic-developer-bundle/issues/279#issuecomment-194110557

Signed-off-by: Lalatendu Mohanty lmohanty@redhat.com
