### PR TITLE
Remove Public_Host variable

### DIFF
--- a/components/centos/centos-openshift-setup/Vagrantfile
+++ b/components/centos/centos-openshift-setup/Vagrantfile
@@ -11,7 +11,6 @@ IMAGE_TAG="v1.1.1"
 # The public IP address the VM created by Vagrant will get.
 # You will use this IP address to connect to OpenShift web console.
 PUBLIC_ADDRESS="10.1.2.2"
-PUBLIC_HOST="adb.cluster.io"
 
 REQUIRED_PLUGINS = %w(vagrant-service-manager)
 errors = []


### PR DESCRIPTION
Currently we are using `1.1.1` tag which is older and we should be using `1.1.3` and `PUBLIC_HOST` is a unused variable which should be removed.
