### PR TITLE
Removed development group packages from kickstart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 - Fix #353: Add VSM config to docker setup and removed Vagrantbox Readme @praveenkumar
 - Bumping /etc/os-release to 2.1.0 @LalatenduMohanty
+- Remove development group from kickstart @praveenkumar
 
 ## v2.0.0 Apr 28, 2016
 - Fix #351 Suppress logs from systemctl enable for kubernetes @praveenkumar

--- a/build_tools/kickstarts/centos-7-adb-vagrant.ks
+++ b/build_tools/kickstarts/centos-7-adb-vagrant.ks
@@ -28,7 +28,6 @@ reboot
 
 %packages
 @core
-@development
 docker
 deltarpm
 rsync

--- a/build_tools/kickstarts/rhel-7-cdk-vagrant.ks
+++ b/build_tools/kickstarts/rhel-7-cdk-vagrant.ks
@@ -28,7 +28,6 @@ reboot
 
 %packages
 docker
-@development
 deltarpm
 rsync
 nfs-utils

--- a/build_tools/kickstarts/rhel-7-kubernetes-vagrant.ks
+++ b/build_tools/kickstarts/rhel-7-kubernetes-vagrant.ks
@@ -27,7 +27,6 @@ reboot
 
 %packages
 @core
-@development
 docker
 deltarpm
 rsync


### PR DESCRIPTION
@development group packages are around 100MB in size and we don't require all those packages so removing it reduced a bit size for vagrant box.
