### PR TITLE
Removing PUBLIC_HOST="adb.cluster.io" as it is not required anymore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 - Fix #353: Add VSM config to docker setup and removed Vagrantbox Readme @praveenkumar
+- Removing adb.cluster.io from CentOS-OpenShift Vagrantfile @LalatenduMohanty
 
 ## v2.0.0 Apr 28, 2016
 - Fix #351 Suppress logs from systemctl enable for kubernetes @praveenkumar

--- a/components/centos/centos-openshift-setup/Vagrantfile
+++ b/components/centos/centos-openshift-setup/Vagrantfile
@@ -11,7 +11,6 @@ IMAGE_TAG="v1.1.1"
 # The public IP address the VM created by Vagrant will get.
 # You will use this IP address to connect to OpenShift web console.
 PUBLIC_ADDRESS="10.1.2.2"
-PUBLIC_HOST="adb.cluster.io"
 
 REQUIRED_PLUGINS = %w(vagrant-service-manager)
 errors = []


### PR DESCRIPTION
Signed-off-by: Lalatendu Mohanty lmohanty@redhat.com
