### PR TITLE
Add cockpit-kubernetes to enable Kube use case

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unreleased
+-Fix #396 - modify Cockpit to have Kubernetes bridge and not drag in unecessary packages @bexelbie
 
 ## v2.1.0 May 19, 2016
 - Fix #353: Add VSM config to docker setup and removed Vagrantbox Readme @praveenkumar

--- a/build_tools/kickstarts/centos-7-adb-vagrant.ks
+++ b/build_tools/kickstarts/centos-7-adb-vagrant.ks
@@ -48,7 +48,11 @@ adb-utils
 centos-release-adb
 fuse-sshfs
 openshift2nulecule
-cockpit
+# Cockpit interface - adds basic functionality followed by docker, kube, and network components
+cockpit-ws
+cockpit-docker
+cockpit-kubernetes
+cockpit-networkmanager
 %end
 
 %post


### PR DESCRIPTION
The kubernetes cockpit plugin isn't installed by default
This also reduces the code installed by only installing the interface
and the docker, kubernetes, and network components.

Storage is ommitted because we don't need to drag in the dependencies
and the use case doesn't seem strong.

Fix #396
