### PR TITLE
Fixes #347. Modified Vagrantfiles to run provisioners for every vagrant up

### DIFF
--- a/components/centos/centos-k8s-singlenode-setup/Vagrantfile
+++ b/components/centos/centos-k8s-singlenode-setup/Vagrantfile
@@ -54,7 +54,7 @@ Vagrant.configure(2) do |config|
     config.ssh.username = 'vagrant'
   end
 
-  config.vm.provision "shell", inline: <<-SHELL
+  config.vm.provision "shell", run: "always", inline: <<-SHELL
     sudo mkdir -p /etc/pki/kube-apiserver/
     sudo openssl genrsa -out /etc/pki/kube-apiserver/serviceaccount.key 2048 > /dev/null 2>&1
     sudo sed -i.back '/KUBE_API_ARGS=*/c\KUBE_API_ARGS="--service_account_key_file=/etc/pki/kube-apiserver/serviceaccount.key"' /etc/kubernetes/apiserver

--- a/components/centos/centos-mesos-marathon-singlenode-setup/Vagrantfile
+++ b/components/centos/centos-mesos-marathon-singlenode-setup/Vagrantfile
@@ -50,7 +50,7 @@ Vagrant.configure("2") do |config|
     config.ssh.username = 'vagrant'
   end
 
-  config.vm.provision "shell", inline: <<-SHELL
+  config.vm.provision "shell", run: "always", inline: <<-SHELL
     sudo yum -y install epel-release
     sudo yum -y install ansible
     sudo ansible-playbook -e ip_address=#{IP_ADDRESS} /vagrant/provisioning/playbook.yml

--- a/components/centos/centos-openshift-setup/Vagrantfile
+++ b/components/centos/centos-openshift-setup/Vagrantfile
@@ -70,11 +70,11 @@ Vagrant.configure(2) do |config|
 
   config.vm.network "private_network", ip: "#{PUBLIC_ADDRESS}"
 
-  config.vm.provision "shell", inline: <<-SHELL
+  config.vm.provision "shell", run: "always", inline: <<-SHELL
     sudo DOCKER_REGISTRY=#{DOCKER_REGISTRY} IMAGE_TAG=#{IMAGE_TAG} IMAGE_NAME=#{IMAGE_NAME} /usr/bin/sccli openshift
   SHELL
 
-  config.vm.provision "shell", privileged: false, inline: <<-SHELL
+  config.vm.provision "shell", run: "always", privileged: false, inline: <<-SHELL
     echo "You can now access OpenShift console on: https://#{PUBLIC_ADDRESS}:8443/console"
     echo
     echo "Configured basic user: openshift-dev, Password: devel"

--- a/components/rhel/misc/rhel-k8s-singlenode-setup/Vagrantfile
+++ b/components/rhel/misc/rhel-k8s-singlenode-setup/Vagrantfile
@@ -38,7 +38,7 @@ Vagrant.configure(2) do |config|
   # Fix for ADB #334
   config.servicemanager.services = 'docker'
 
-  config.vm.provision "shell", inline: <<-SHELL
+  config.vm.provision "shell", run: "always", inline: <<-SHELL
      sudo mkdir -p /etc/pki/kube-apiserver/
      sudo openssl genrsa -out /etc/pki/kube-apiserver/serviceaccount.key 2048 > /dev/null 2>&1
      sudo sed -i.back '/KUBE_API_ARGS=*/c\KUBE_API_ARGS="--service_account_key_file=/etc/pki/kube-apiserver/serviceaccount.key"' /etc/kubernetes/apiserver

--- a/components/rhel/rhel-ose/Vagrantfile
+++ b/components/rhel/rhel-ose/Vagrantfile
@@ -49,12 +49,12 @@ Vagrant.configure(2) do |config|
 
   config.servicemanager.services = "docker"
 
-  config.vm.provision "shell", inline: <<-SHELL
+  config.vm.provision "shell", run: "always", inline: <<-SHELL
     systemctl enable openshift 2>&1
     systemctl start openshift
   SHELL
 
-  config.vm.provision "shell", inline: <<-SHELL
+  config.vm.provision "shell", run: "always", inline: <<-SHELL
     echo
     echo "Successfully started and provisioned VM with #{VM_CPU} cores and #{VM_MEMORY} MB of memory."
     echo "To modify the number of cores and/or available memory set the environment variables"


### PR DESCRIPTION
Added run: "always" to the provisioners to run them incase of
 vagrant up -> vagrant halt -> vagrant up or for vagrant reload.

As by-default provisioners are only run once, during the first
 vagrant up since the last vagrant destroy, unless the --provision
flag is set.

Signed-off-by: Lalatendu Mohanty lmohanty@redhat.com
