### PR TITLE
Fix #422 Failed to get pwuid struct: user: unknown userid

### DIFF
--- a/build_tools/kickstarts/centos-7-adb-vagrant.ks
+++ b/build_tools/kickstarts/centos-7-adb-vagrant.ks
@@ -83,6 +83,10 @@ cockpit
 # Workaround for BZ1336857
 restorecon -v /usr/bin/docker*
 
+# Workaround for BZ1335635#c12
+echo "dockerlog:x:4294967295:4294967295::/var/lib/docker:/bin/nologin" >> /etc/passwd
+echo "dockerlog:x:4294967295:4294967295::/var/lib/docker:/bin/nologin" >> /etc/group
+
 LANG="en_US"
 echo "%_install_lang $LANG" > /etc/rpm/macros.image-language-conf
 

--- a/build_tools/kickstarts/rhel-7-cdk-vagrant.ks
+++ b/build_tools/kickstarts/rhel-7-cdk-vagrant.ks
@@ -84,6 +84,10 @@ openshift2nulecule
 # Workaround for BZ1336857
 restorecon -v /usr/bin/docker*
 
+# Workaround for BZ1335635#c12
+echo "dockerlog:x:4294967295:4294967295::/var/lib/docker:/bin/nologin" >> /etc/passwd
+echo "dockerlog:x:4294967295:4294967295::/var/lib/docker:/bin/nologin" >> /etc/group
+
 LANG="en_US"
 echo "%_install_lang $LANG" > /etc/rpm/macros.image-language-conf
 


### PR DESCRIPTION
This patch will be workaround for syslogs are filled with the message "failed to get pwuid struct: user: unknown userid 4294967295" once we start openshift service on our current docker version. We get around three entries of the above message in a second.

```
Jun 06 02:16:54 rhel-cdk forward-journal[15613]: time="2016-06-06T02:16:54.302281649-04:00" level=error msg="Failed to get pwuid struct: user: unknown userid 4294967295"
Jun 06 02:16:54 rhel-cdk forward-journal[15613]: time="2016-06-06T02:16:54.624714214-04:00" level=error msg="Failed to get pwuid struct: user: unknown userid 4294967295"
Jun 06 02:16:54 rhel-cdk forward-journal[15613]: time="2016-06-06T02:16:54.628273306-04:00" level=error msg="Failed to get pwuid struct: user: unknown userid 4294967295"
```
