### PR TITLE
Fix #289 Can not change securityContext in k8s

### DIFF
--- a/build_tools/kickstarts/centos-7-adb-vagrant.ks
+++ b/build_tools/kickstarts/centos-7-adb-vagrant.ks
@@ -87,6 +87,10 @@ restorecon -v /usr/bin/docker*
 echo "dockerlog:x:4294967295:4294967295::/var/lib/docker:/bin/nologin" >> /etc/passwd
 echo "dockerlog:x:4294967295:4294967295::/var/lib/docker:/bin/nologin" >> /etc/group
 
+# Fix for #117 and #289
+chcon -Rt svirt_sandbox_file_t /var/lib/kubelet
+sed -i -e 's/SecurityContextDeny,//' /etc/kubernetes/apiserver
+
 LANG="en_US"
 echo "%_install_lang $LANG" > /etc/rpm/macros.image-language-conf
 

--- a/build_tools/kickstarts/rhel-7-cdk-vagrant.ks
+++ b/build_tools/kickstarts/rhel-7-cdk-vagrant.ks
@@ -91,6 +91,10 @@ echo "dockerlog:x:4294967295:4294967295::/var/lib/docker:/bin/nologin" >> /etc/g
 LANG="en_US"
 echo "%_install_lang $LANG" > /etc/rpm/macros.image-language-conf
 
+# Fix for #117 and #289
+chcon -Rt svirt_sandbox_file_t /var/lib/kubelet
+sed -i -e 's/SecurityContextDeny,//' /etc/kubernetes/apiserver
+
 # Add cdk version info to consumed by adbinfo
 # https://github.com/projectatomic/adb-atomic-developer-bundle/issues/183
 echo "VARIANT=\"Container Development Kit (CDK)\"" >> /etc/os-release


### PR DESCRIPTION
This patch will fix securityContext for k8s and also address #117 (except documentation part).
