### PR TITLE
Fix #428 Success message after vagrant up for k8s-singlenode-setup

### DIFF
--- a/components/centos/centos-k8s-singlenode-setup/Vagrantfile
+++ b/components/centos/centos-k8s-singlenode-setup/Vagrantfile
@@ -55,29 +55,15 @@ Vagrant.configure(2) do |config|
   end
 
   config.vm.provision "shell", run: "always", inline: <<-SHELL
-    sudo mkdir -p /etc/pki/kube-apiserver/
-    sudo openssl genrsa -out /etc/pki/kube-apiserver/serviceaccount.key 2048 > /dev/null 2>&1
-    sudo sed -i.back '/KUBE_API_ARGS=*/c\KUBE_API_ARGS="--service_account_key_file=/etc/pki/kube-apiserver/serviceaccount.key"' /etc/kubernetes/apiserver
-    sudo sed -i.back '/KUBE_CONTROLLER_MANAGER_ARGS=*/c\KUBE_CONTROLLER_MANAGER_ARGS="--service_account_private_key_file=/etc/pki/kube-apiserver/serviceaccount.key"' /etc/kubernetes/controller-manager
-
-    echo "setup master"
-    for service in etcd kube-apiserver kube-controller-manager kube-scheduler; do
-      echo "  enable $service"
-      sudo systemctl enable $service > /dev/null 2>&1
-
-      echo "  start $service"
-      sudo systemctl start $service
-    done
-
-    echo "setup nodes"
-    for service in kube-proxy kubelet; do
-      echo "  enable $service"
-      sudo systemctl enable $service > /dev/null 2>&1
-
-      echo "  start $service"
-      sudo systemctl start $service
-    done
-    echo "  restart docker"
-    sudo systemctl restart docker
+     sudo mkdir -p /etc/pki/kube-apiserver/
+     sudo openssl genrsa -out /etc/pki/kube-apiserver/serviceaccount.key 2048 > /dev/null 2>&1
+     sudo sed -i.back '/KUBE_API_ARGS=*/c\KUBE_API_ARGS="--service_account_key_file=/etc/pki/kube-apiserver/serviceaccount.key"' /etc/kubernetes/apiserver
+     sudo sed -i.back '/KUBE_CONTROLLER_MANAGER_ARGS=*/c\KUBE_CONTROLLER_MANAGER_ARGS="--service_account_private_key_file=/etc/pki/kube-apiserver/serviceaccount.key"' /etc/kubernetes/controller-manager
+     sudo systemctl enable etcd kube-apiserver kube-controller-manager kube-scheduler > /dev/null 2>&1
+     sudo systemctl start etcd kube-apiserver kube-controller-manager kube-scheduler
+     sudo systemctl enable kube-proxy kubelet > /dev/null 2>&1
+     sudo systemctl start kube-proxy kubelet
+     sudo systemctl restart docker
+     echo "kubernetes-single-node-setup configured successfully"
   SHELL
 end

--- a/components/rhel/misc/rhel-k8s-singlenode-setup/Vagrantfile
+++ b/components/rhel/misc/rhel-k8s-singlenode-setup/Vagrantfile
@@ -45,12 +45,11 @@ Vagrant.configure(2) do |config|
      sudo openssl genrsa -out /etc/pki/kube-apiserver/serviceaccount.key 2048 > /dev/null 2>&1
      sudo sed -i.back '/KUBE_API_ARGS=*/c\KUBE_API_ARGS="--service_account_key_file=/etc/pki/kube-apiserver/serviceaccount.key"' /etc/kubernetes/apiserver
      sudo sed -i.back '/KUBE_CONTROLLER_MANAGER_ARGS=*/c\KUBE_CONTROLLER_MANAGER_ARGS="--service_account_private_key_file=/etc/pki/kube-apiserver/serviceaccount.key"' /etc/kubernetes/controller-manager
-
      sudo systemctl enable etcd kube-apiserver kube-controller-manager kube-scheduler > /dev/null 2>&1
      sudo systemctl start etcd kube-apiserver kube-controller-manager kube-scheduler
-
      sudo systemctl enable kube-proxy kubelet > /dev/null 2>&1
      sudo systemctl start kube-proxy kubelet
      sudo systemctl restart docker
+     echo "kubernetes-single-node-setup configured successfully"
   SHELL
 end


### PR DESCRIPTION
This patch will provide a success message when we do vagrant up for k8s-singlenode-setup.
