### PR TITLE
Adding OpenShift Vagrant Service

### DIFF
--- a/components/centos/centos-openshift-setup/Vagrantfile
+++ b/components/centos/centos-openshift-setup/Vagrantfile
@@ -35,6 +35,8 @@ end
 
 Vagrant.configure(2) do |config|
   config.vm.box = 'projectatomic/adb'
+  
+  config.servicemanager.services = 'openshift'
 
   config.vm.provider "virtualbox" do |v, override|
     v.memory = 2048


### PR DESCRIPTION
From what I learned this Vagrantfile should use the Vagrant OpenShift Service based on the notes here: 
https://github.com/projectatomic/adb-atomic-developer-bundle/blob/master/docs/using.rst#using-the-adb-with-host-based-tools-eclipse-and-clis
