### PR TITLE
marathon: setup so that ports from host can be shared

### DIFF
--- a/components/centos/centos-mesos-marathon-singlenode-setup/provisioning/playbook.yml
+++ b/components/centos/centos-mesos-marathon-singlenode-setup/provisioning/playbook.yml
@@ -15,6 +15,11 @@
                 content: '{{ ip_address }}'
                 dest: /etc/mesos-slave/ip
 
+          - name: Configure Port Ranges for mesos-slave
+            copy: 
+                content: 'ports:[1024-32000]'
+                dest: /etc/mesos-slave/resources
+
           - name: Increase timeout to account for docker pull delay
             copy: 
                 content: '5mins'


### PR DESCRIPTION
We are configuring so that ports from the host can be mapped directly
to containers as described in the following link:

http://container-solutions.com/configuring-resource-offers-on-mesos/
