### PR TITLE
Add Landrush as plugin requirement in Vagrantfile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## v2.3.0 Aug 10, 2016
+- Add Landrush as plugin requirement in Vagrantfile @praveenkumar
+- Unify Vagrantfile for different Providers @praveenkumar
 - Fixes issue #488. Using ENV variables for proxy @LalatenduMohanty
 - Issue #461 Enabling Landrush per default @hferentschik
 - Fix a couple broken links @shawnlower

--- a/components/centos/centos-openshift-setup/Vagrantfile
+++ b/components/centos/centos-openshift-setup/Vagrantfile
@@ -18,7 +18,7 @@ HOSTNAME = 'adb.vm'
 # Host name for accessing OpenShift
 OPENSHIFT_HOSTNAME = "openshift.#{TLD}"
 
-REQUIRED_PLUGINS = %w(vagrant-service-manager vagrant-sshfs)
+REQUIRED_PLUGINS = %w(vagrant-service-manager vagrant-sshfs landrush)
 errors = []
 
 def message(name)
@@ -40,6 +40,7 @@ end
 
 Vagrant.configure(2) do |config|
   config.vm.box = 'projectatomic/adb'
+  config.vm.hostname = HOSTNAME
 
   config.vm.provider "virtualbox" do |v, override|
     v.memory = 2048


### PR DESCRIPTION
This patch will add landrush as dependent plugin for CentOS now.
