### PR TITLE
Fix #503 Minor change to Vagrantfile to enable oc login

### DIFF
--- a/components/rhel/rhel-ose/Vagrantfile
+++ b/components/rhel/rhel-ose/Vagrantfile
@@ -99,7 +99,7 @@ Vagrant.configure(2) do |config|
     echo
     echo "To use OpenShift CLI, run:"
     echo "$ vagrant ssh"
-    echo "$ oc login #{OPENSHIFT_HOSTNAME }:8443"
+    echo "$ oc login"
     echo
     echo "Configured users are (<username>/<password>):"
     echo "openshift-dev/devel"


### PR DESCRIPTION
Landrush generated TLD is not pingable from guest. If a user do vagrant ssh then it openshift is running and can be accessible by localhost also so no need to mention TLD. 
