### PR TITLE
Updated centos-k8s Vagrantfile to start through service-manager hook

### DIFF
--- a/components/centos/centos-k8s-singlenode-setup/Vagrantfile
+++ b/components/centos/centos-k8s-singlenode-setup/Vagrantfile
@@ -64,16 +64,5 @@ Vagrant.configure(2) do |config|
     sudo setsebool -P virt_sandbox_use_fusefs 1
   SHELL
 
-  config.vm.provision "shell", run: "always", inline: <<-SHELL
-     sudo mkdir -p /etc/pki/kube-apiserver/
-     sudo openssl genrsa -out /etc/pki/kube-apiserver/serviceaccount.key 2048 > /dev/null 2>&1
-     sudo sed -i.back '/KUBE_API_ARGS=*/c\KUBE_API_ARGS="--service_account_key_file=/etc/pki/kube-apiserver/serviceaccount.key"' /etc/kubernetes/apiserver
-     sudo sed -i.back '/KUBE_CONTROLLER_MANAGER_ARGS=*/c\KUBE_CONTROLLER_MANAGER_ARGS="--service_account_private_key_file=/etc/pki/kube-apiserver/serviceaccount.key"' /etc/kubernetes/controller-manager
-     sudo systemctl enable etcd kube-apiserver kube-controller-manager kube-scheduler > /dev/null 2>&1
-     sudo systemctl start etcd kube-apiserver kube-controller-manager kube-scheduler
-     sudo systemctl enable kube-proxy kubelet > /dev/null 2>&1
-     sudo systemctl start kube-proxy kubelet
-     sudo systemctl restart docker
-     echo "kubernetes-single-node-setup configured successfully"
-  SHELL
+  config.servicemanager.services = 'kubernetes'
 end

--- a/components/rhel/misc/rhel-k8s-singlenode-setup/Vagrantfile
+++ b/components/rhel/misc/rhel-k8s-singlenode-setup/Vagrantfile
@@ -37,9 +37,6 @@ Vagrant.configure(2) do |config|
   end
   config.vm.network "private_network", type: "dhcp"
 
-  # Fix for ADB #334
-  config.servicemanager.services = 'docker'
-
   if Vagrant::Util::Platform.windows?
     target_path = ENV['USERPROFILE'].gsub(/\\/,'/').gsub(/[[:alpha:]]{1}:/){|s|'/' + s.downcase.sub(':', '')}
     config.vm.synced_folder ENV['USERPROFILE'], target_path, type: 'sshfs', sshfs_opts_append: '-o umask=000 -o uid=1000 -o gid=1000'
@@ -50,16 +47,5 @@ Vagrant.configure(2) do |config|
     sudo setsebool -P virt_sandbox_use_fusefs 1
   SHELL
 
-  config.vm.provision "shell", run: "always", inline: <<-SHELL
-     sudo mkdir -p /etc/pki/kube-apiserver/
-     sudo openssl genrsa -out /etc/pki/kube-apiserver/serviceaccount.key 2048 > /dev/null 2>&1
-     sudo sed -i.back '/KUBE_API_ARGS=*/c\KUBE_API_ARGS="--service_account_key_file=/etc/pki/kube-apiserver/serviceaccount.key"' /etc/kubernetes/apiserver
-     sudo sed -i.back '/KUBE_CONTROLLER_MANAGER_ARGS=*/c\KUBE_CONTROLLER_MANAGER_ARGS="--service_account_private_key_file=/etc/pki/kube-apiserver/serviceaccount.key"' /etc/kubernetes/controller-manager
-     sudo systemctl enable etcd kube-apiserver kube-controller-manager kube-scheduler > /dev/null 2>&1
-     sudo systemctl start etcd kube-apiserver kube-controller-manager kube-scheduler
-     sudo systemctl enable kube-proxy kubelet > /dev/null 2>&1
-     sudo systemctl start kube-proxy kubelet
-     sudo systemctl restart docker
-     echo "kubernetes-single-node-setup configured successfully"
-  SHELL
+  config.servicemanager.services = 'kubernetes'
 end


### PR DESCRIPTION
This patch is need to run `kubernetes` through vagrant-service-manager as part of `vagrant up` hook so that kube config can be generated properly.

One alternative way is to only generate kube config through vagrant-service-manager plugin only.
Right now, it is getting generate through two ways:
- One during vagrant up process only if kubernetes is mentioned in `config.servicemanager.services` configuration
- If user start kubernetes through CLI as `vagrant service-manager start kubernetes`

Another approach could be:
- Generate when user fire `env kubernetes` command
- Generate when user install kubernetes client binary through `install-cli` command. 
