### PR TITLE
 Fix #481 Restructured Usage doc 

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -3,49 +3,53 @@
    :depth: 2
    :backlinks: none
 
-What is the Atomic Developer Bundle (ADB)?
+What is Atomic Developer Bundle (ADB)?
 ==========================================
 
-The Atomic Developer Bundle (ADB) is a prepackaged development
+Atomic Developer Bundle (ADB) is a prepackaged development
 environment filled with production-grade, pre-configured tools, that makes
-container developers' lives easier.  The ADB supports the development
+container developers' lives easier. ADB supports the development
 of multi-container applications against different technologies and
 orchestrators while providing a path that promotes best practices.
 
-As a container developer, you want to use the ADB for these reasons:
+As a container developer, you want to use ADB for these reasons:
 
 * **Pre-Configured**: You don't have to spend time building an environment
   and fighting configuration battles.
-* **Multiple Environment Support**: The ADB works on Windows, Linux and Mac
-  OS X. The ADB supports several orchestrators (OpenShift, Kubernetes,
-  Mesos, and plain Docker). The ADB is language independent and supports
+* **Multiple Environment Support**: ADB works on Windows, Linux and Mac
+  OS X. ADB supports several orchestrators (OpenShift, Kubernetes,
+  Mesos, and plain Docker). ADB is language independent and supports
   multiple developer models (IDE, CLI, SSH containment).
-* **Production-Grade**: The components of the ADB are configured to behave
+* **Production-Grade**: The components of ADB are configured to behave
   just as they will in production. Containers promise seamless delivery,
   but only if you test them in the right environment. This is that
   environment.
-* **Self-Contained**: The ADB is ready to go once installed. It comes
+* **Self-Contained**: ADB is ready to go once installed. It comes
   prepackaged with the most common components ready, in case they
   are needed.
-* **Open Source**: The ADB leverages existing tools and technologies wherever possible to avoid pushing a developer into an environment that won't be supportable in production or that is tied to a single vendor.
+* **Open Source**: ADB leverages existing tools and technologies wherever
+  possible to avoid pushing a developer into an environment that won't be supportable
+  in production or that is tied to a single vendor.
   This also means it benefits from the stability of existing projects
   instead of reinventing the wheel.
 
-The ADB is a virtual machine that is executed with Vagrant and some Vagrant plugins.
+ADB is a virtual machine that is executed with Vagrant and some Vagrant plugins.
 
-When would the ADB typically be used?
+When would ADB typically be used?
 ===============================================================
 
-A developer begins using the ADB, in most cases, once they have a
+A developer begins using ADB, in most cases, once they have a
 working application that has been decomposed into micro-services.
 They then follow this general outline of steps:
 
-1. Consider ways to divide your application into its component services or micro-services. For standard pieces, such as web servers, consider using pre-built containers from trusted sources. For truly unique pieces, build a custom container.
-2. Confirm the application works in the ADB by manually launching the
+1. Consider ways to divide your application into its component services or
+   micro-services. For standard pieces, such as web servers, consider using
+   pre-built containers from trusted sources. For truly unique pieces, build a custom container.
+2. Confirm the application works in ADB by manually launching the
    application's container components or by using the instance of
    OpenShift in the container to launch the application.
-3. Build a Nulecule description of the application or complete the
-   OpenShift application configuration.
+3. Build orchestration configurations that provide scaling and other required features, or complete the
+   OpenShift application configuration. Alternatively, build a Nulecule description of the application.
 4. Test the application.
 
 The `Container Best Practices`_ document in this project may also be of interest.
@@ -55,51 +59,52 @@ The `Container Best Practices`_ document in this project may also be of interest
 What is the Typical Usage Pattern?
 ==================================
 
-The ADB supports three basic modes of usage.  The modes vary by how much
+ADB supports three basic modes of usage.  The modes vary by how much
 they rely on tools on the developer's workstation.  From most to least
 reliant, they are:
 
 * Host-based IDE Mode
 
-  This mode uses the ADB as a server resource for host-based IDE tools.
+  This mode uses ADB as a server resource for host-based IDE tools.
   In this mode, the user will run ``eclipse`` or other IDE tools that will
-  access the resources of the ADB.
+  access the resources of ADB.
 
 * Host-based CLI Mode
 
-  This mode uses the ADB as a server resource for host-based CLI tools.
+  This mode uses ADB as a server resource for host-based CLI tools.
   In this mode, the user will run ``docker`` and other CLI tools on their
   workstation and the result will be containers executed inside of
-  the ADB.
+  ADB.
 
 * SSH Mode
 
-  This mode uses the ADB as a Linux virtual machine.  The user will
-  use the ``ssh`` command to log into the ADB and will directly execute
+  This mode uses ADB as a Linux virtual machine.  The user will
+  use the ``ssh`` command to log into ADB and will directly execute
   ``docker`` and other commands from the command line.  This is similar
   to having installed a Linux virtual machine and then installing and
-  configuring all of the software the ADB ships with.
+  configuring all of the software ADB ships with.
 
-More information about `using the ADB`_ is available.
+More information about `using ADB`_ is available.
 
-.. _using the ADB: docs/using.rst
+.. _using ADB: docs/using.rst
 
 What does it Utilize?
 =====================
 
-The ADB is built on top of `CentOS 7`_ and the following projects:
+ADB is built on top of `CentOS 7`_ and the following projects:
 
 * `Docker`_: container runtime and packaging
 * `Atomic CLI`_: container usage assistance
 * `Kubernetes`_: container orchestration
-* `OpenShift Origin`_: a next generation PaaS for docker containers.
+* `OpenShift Origin`_: a next generation PaaS for docker containers
 * `openshift2nulecule`_: a tool that creates a Nulecule application from an existing OpenShift project
 * `Mesos Marathon`_: a production-grade container orchestration platform for Mesosphere's Datacenter Operating System (DCOS) and Apache Mesos
 
-The ADB supports `Atomic App`_, an implementation of the multi-container
-application specification `nulecule`_, for multi-container applications.
+ADB supports `Atomic App`_, an implementation of the multi-container application
+specification `nulecule`_, for multi-container applications.
 
-You need to use the customized Vagrantfiles provided in the ADB project to set up the above mentioned environments. For further details refer to the Installation steps in the next section.
+You need to use the customized Vagrantfiles provided in ADB project to set up
+the above mentioned environments. For further details refer to the Installation steps in the next section.
 
 .. _CentOS 7: https://www.centos.org/
 .. _Docker: https://www.docker.com/
@@ -111,66 +116,76 @@ You need to use the customized Vagrantfiles provided in the ADB project to set u
 .. _openshift2nulecule: https://github.com/projectatomic/openshift2nulecule/
 .. _Mesos Marathon: https://mesosphere.github.io/marathon/
 
-How do I Install and Run the ADB?
+How do I Install and Run ADB?
 ===========================================================
 
 Below is a quick installation guide using the most common options.
 Detailed `installation instructions`_ are available.
 
+
 1. `Install VirtualBox`_ for your operating system.
 
 2. `Install Vagrant`_ for your operating system.
 
-3. Install the `vagrant-service-manager`_ Vagrant plugin:
+3. Install the Vagrant plugins; `vagrant-service-manager`_, `vagrant-sshfs`_, and `landrush`_.
 
-   ``vagrant plugin install vagrant-service-manager``
+   **Note:** Some operating systems may need additional dependencies to be installed before
+   you proceed with the installation of the vagrant plugins. For details refer to
+   the detailed `Installation document`_.
 
-4. Download the customized Vagrantfiles provided by the ADB project. These Vagrantfiles will download the ADB and automatically set up provider specific container development environments. They are listed below and more details are available in the `Using Custom Vagrantfiles for Specific Use Cases`_ section of the `Using the Atomic Developer Bundle`_ document and the `Installation document`_.
+   ``$ vagrant plugin install vagrant-service-manager vagrant-sshfs landrush``
 
-   To download the ADB and set up provider specific container development environment:
+4. Download the customized Vagrantfiles provided by the ADB project.
+   These Vagrantfiles will download ADB and automatically set up provider-specific
+   container development environments. They are listed below and more details are
+   available in the `Installation document`_.
+
+   To download ADB and set up a provider-specific container development environment:
 
    1. Create a directory for the Vagrant box
 
       ``$ mkdir directory && cd directory``
-   
-   2. Download any of the following vagrantfiles, based on your requirements, to download the ADB and use it with host-based tools or via ``vagrant ssh``.
- 
-      * For `Docker Vagrantfile`_ use::
+
+   2. Download any of the following vagrantfiles, to configure the development environment you need.
+
+      * To configure a `Docker specific container development environment`_ use::
 
         $ curl -sL https://raw.githubusercontent.com/projectatomic/adb-atomic-developer-bundle/master/components/centos/centos-docker-base-setup/Vagrantfile > Vagrantfile
-        
-      * For `Kubernetes Vagrantfile`_ use::
+
+      * To configure a `Kubernetes specific container development environment`_ use::
 
         $ curl -sL https://raw.githubusercontent.com/projectatomic/adb-atomic-developer-bundle/master/components/centos/centos-k8s-singlenode-setup/Vagrantfile > Vagrantfile
 
-      * For `OpenShift Origin Vagrantfile`_ use::
+      * To configure an `OpenShift Origin specific container development environment`_ use::
 
         $ curl -sL https://raw.githubusercontent.com/projectatomic/adb-atomic-developer-bundle/master/components/centos/centos-openshift-setup/Vagrantfile > Vagrantfile
 
-      * For `Apache Mesos Marathon Vagrantfile`_ use::
+      * To configure an `Apache Mesos Marathon specific container development environment`_ use::
 
         $ curl -sL https://raw.githubusercontent.com/projectatomic/adb-atomic-developer-bundle/master/components/centos/centos-mesos-marathon-singlenode-setup/Vagrantfile > Vagrantfile
 
-.. _Using Custom Vagrantfiles for Specific Use Cases: https://github.com/projectatomic/adb-atomic-developer-bundle/blob/master/docs/using.rst#using-custom-vagrantfiles-for-specific-use-cases
-.. _Using the Atomic Developer Bundle: docs/using.rst
-.. _Installation document: https://github.com/projectatomic/adb-atomic-developer-bundle/blob/master/docs/installing.rst
-.. _Docker Vagrantfile: https://github.com/projectatomic/adb-atomic-developer-bundle/blob/master/components/centos/centos-docker-base-setup/Vagrantfile
-.. _Kubernetes Vagrantfile: https://github.com/projectatomic/adb-atomic-developer-bundle/blob/master/components/centos/centos-k8s-singlenode-setup/Vagrantfile
-.. _OpenShift Origin Vagrantfile: https://github.com/projectatomic/adb-atomic-developer-bundle/blob/master/components/centos/centos-openshift-setup/Vagrantfile
-.. _Apache Mesos Marathon Vagrantfile: https://github.com/projectatomic/adb-atomic-developer-bundle/blob/master/components/centos/centos-mesos-marathon-singlenode-setup/Vagrantfile
 
-5. Start the ADB
+5. Start ADB
 
    ``vagrant up``
 
-This will download the ADB and set it up to work with the provider of choice for use with host-based tools or via ``vagrant ssh``.
-You may wish to review the `Using the Atomic Developer Bundle`_ documentation before starting the ADB, especially if you are using host-based tools.
+This will download ADB and set it up to work with the provider of choice, for
+use with host-based tools or via ``vagrant ssh``.
+You may wish to review the `Using Atomic Developer Bundle`_ documentation
+before starting ADB, especially if you are using host-based tools.
 
 .. _installation instructions: docs/installing.rst
 .. _Install VirtualBox: https://www.virtualbox.org/wiki/Downloads
 .. _Install Vagrant: https://docs.vagrantup.com/v2/installation/index.html
 .. _vagrant-service-manager: https://github.com/projectatomic/vagrant-service-manager
-.. _Using the Atomic Developer Bundle: docs/using.rst
+.. _vagrant-sshfs: https://github.com/dustymabe/vagrant-sshfs
+.. _landrush: https://github.com/vagrant-landrush/landrush
+.. _Installation document: https://github.com/projectatomic/adb-atomic-developer-bundle/blob/master/docs/installing.rst
+.. _Docker specific container development environment: https://github.com/projectatomic/adb-atomic-developer-bundle/blob/master/components/centos/centos-docker-base-setup/Vagrantfile
+.. _Kubernetes specific container development environment: https://github.com/projectatomic/adb-atomic-developer-bundle/blob/master/components/centos/centos-k8s-singlenode-setup/Vagrantfile
+.. _OpenShift Origin specific container development environment: https://github.com/projectatomic/adb-atomic-developer-bundle/blob/master/components/centos/centos-openshift-setup/Vagrantfile
+.. _Apache Mesos Marathon specific container development environment: https://github.com/projectatomic/adb-atomic-developer-bundle/blob/master/components/centos/centos-mesos-marathon-singlenode-setup/Vagrantfile
+.. _Using Atomic Developer Bundle: docs/using.rst
 
 What is full feature set?
 =========================
@@ -190,7 +205,7 @@ Additional goals, objectives and work in progress can be found in the `architect
 What are the deliverables and how do I get it?
 ==============================================
 
-The ADB is delivered as a Vagrant box for various (currently libvirt and
+ADB is delivered as a Vagrant box for various (currently libvirt and
 VirtualBox) providers.  The boxes are built using the CentOS powered
 `Community Build System`_.  Boxes are delivered via `Hashicorp's
 Atlas`_ and are available at `cloud.centos.org`_.  These boxes differ
@@ -204,19 +219,19 @@ requirements that are not enabled in those boxes.
 Documentation
 =============
 
-* `Installing the ADB`_
-* `How to use the ADB`_
+* `Installing ADB`_
+* `How to use ADB`_
 
-  * `Using Cockpit with the ADB`_
+  * `Using Cockpit with ADB`_
 
-* `Updating the ADB`_
+* `Updating ADB`_
 * `Architecture and Roadmap`_
 * `Building the Vagrant box`_ for Developers
 
-.. _Installing the ADB: docs/installing.rst
-.. _How to use the ADB: docs/using.rst
-.. _Using Cockpit with the ADB: docs/cockpit.rst
-.. _Updating the ADB: docs/updating.rst
+.. _Installing ADB: docs/installing.rst
+.. _How to use ADB: docs/using.rst
+.. _Using Cockpit with ADB: docs/cockpit.rst
+.. _Updating ADB: docs/updating.rst
 .. _Architecture and Roadmap: docs/architecture.rst
 .. _Building the Vagrant box: docs/building.rst
 
@@ -235,10 +250,10 @@ reStructuredText editor`_ is available.
 On the web:
 ==========
 
-* Using OpenShift in the ADB : http://www.projectatomic.io/blog/2016/05/App-Development-on-OpenShift-using-ADB
-* Using Kubernetes in the ADB: http://www.projectatomic.io/blog/2016/04/k8s-adb-usage/
-* Introduction to the ADB from DevConf.cz 2016: https://www.youtube.com/watch?v=jxFw6qnGaRk
-* OpenShift in the ADB Quickstart (video): https://www.youtube.com/watch?v=H58prwM3IbE
+* Using OpenShift in ADB : http://www.projectatomic.io/blog/2016/05/App-Development-on-OpenShift-using-ADB
+* Using Kubernetes in ADB: http://www.projectatomic.io/blog/2016/04/k8s-adb-usage/
+* Introduction to ADB from DevConf.cz 2016: https://www.youtube.com/watch?v=jxFw6qnGaRk
+* OpenShift in ADB Quickstart (video): https://www.youtube.com/watch?v=H58prwM3IbE
 
 .. _container-tools@redhat.com: https://www.redhat.com/mailman/listinfo/container-tools
 .. _freenode: https://freenode.net/

--- a/docs/installing.rst
+++ b/docs/installing.rst
@@ -4,23 +4,23 @@
    :backlinks: none
 
 ======================================
-Installing the Atomic Developer Bundle
+Installing Atomic Developer Bundle
 ======================================
 
 ------------------------------------
-1. Install a Virtualization Provider
+1. Install a virtualization provider
 ------------------------------------
 
-Two virtualization providers have been tested with the ADB; VirtualBox and Libvirt.
+Two virtualization providers have been tested with ADB; VirtualBox and Libvirt.
 
 The following virtualization providers are suggested for the respective operating systems:
 
 * Microsoft Windows and Mac OS X
 
-  The suggested virtualization provider for Microsoft Windows and Mac OS X is `VirtualBox`_. Installation
-  instructions are available `online`_. While the latest stable shipping release
-  should work, the majority of testing has been done with version 5.0.0 on Mac
-  OS X and 5.0.8 on Microsoft Windows.
+  The suggested virtualization provider for Microsoft Windows and Mac OS X is
+  `VirtualBox`_. Installation instructions are available `online`_. While the
+  latest stable shipping release should work, the majority of testing has been
+  done with version 5.0.0 on Mac OS X and 5.0.8 on Microsoft Windows.
 
 .. _VirtualBox: https://www.virtualbox.org
 .. _online: https://www.virtualbox.org/manual/UserManual.html
@@ -176,58 +176,77 @@ $ vagrant plugin install landrush
 .. _landrush: https://github.com/vagrant-landrush/landrush
 
 -------------------
-4. Download the ADB
+5. Download ADB
 -------------------
 
-There are two ways to download the ADB.
+There are two ways to download ADB.
 
 * Vagrantfiles Initiated Download
 
-  The ADB project provides customized Vagrantfiles, which will download the ADB and automatically set up provider specific container development environments. They are listed below and more details are available, in the `Using Custom Vagrantfiles for Specific Use Cases`_ section of the `Using the Atomic Developer Bundle`_ document and the `Installation document`_.
+  The ADB project provides customized Vagrantfiles, which will download ADB
+  and automatically set up provider-specific container development environments.
+  They are listed below and more details are available in their respective Readmes.
 
-  To download ADB and set up a provider specific container development environment:
-
+  To download ADB and set up a provider-specific container development environment:
 
   1. Create a directory for the Vagrant box
 
      ``$ mkdir directory && cd directory``
 
-  2. Download any of the following vagrantfiles, based on your requirements, to download the ADB and use it with host-based tools or via ``vagrant ssh``.
+  2. Download any of the following vagrantfiles, to configure the development environment you need.
 
-     * For `Docker Vagrantfile`_ use::
+     * To configure a `Docker`_ specific container development environment use::
 
-        $ curl -sL https://raw.githubusercontent.com/projectatomic/adb-atomic-developer-bundle/master/components/centos/centos-docker-base-setup/Vagrantfile > Vagrantfile
+       $ curl -sL https://raw.githubusercontent.com/projectatomic/adb-atomic-developer-bundle/master/components/centos/centos-docker-base-setup/Vagrantfile > Vagrantfile
 
-
-     * For `Kubernetes Vagrantfile`_ use::
-
-        $ curl -sL https://raw.githubusercontent.com/projectatomic/adb-atomic-developer-bundle/master/components/centos/centos-k8s-singlenode-setup/Vagrantfile > Vagrantfile
-
-     * For `OpenShift Origin Vagrantfile`_ use::
-
-        $ curl -sL https://raw.githubusercontent.com/projectatomic/adb-atomic-developer-bundle/master/components/centos/centos-openshift-setup/Vagrantfile > Vagrantfile
+       Refer: `README <../components/centos/centos-docker-base-setup/README.rst>`_
 
 
-     * For `Apache Mesos Marathon Vagrantfile`_ use::
+     * To configure a `Kubernetes`_ specific container development environment use::
 
-        $curl -sL https://raw.githubusercontent.com/projectatomic/adb-atomic-developer-bundle/master/components/centos/centos-mesos-marathon-singlenode-setup/Vagrantfile > Vagrantfile
+       $ curl -sL https://raw.githubusercontent.com/projectatomic/adb-atomic-developer-bundle/master/components/centos/centos-k8s-singlenode-setup/Vagrantfile > Vagrantfile
 
-  3. Start the ADB
+
+       Refer: `README <../components/centos/centos-k8s-singlenode-setup/README.rst>`_
+
+
+     * To configure an `OpenShift`_ specific container development environment use::
+
+       $ curl -sL https://raw.githubusercontent.com/projectatomic/adb-atomic-developer-bundle/master/components/centos/centos-openshift-setup/Vagrantfile > Vagrantfile
+
+
+       Refer: `README <../components/centos/centos-openshift-setup/README.rst>`_
+
+
+     * To configure an `Apache Mesos Marathon`_ specific container development environment use::
+
+       $curl -sL https://raw.githubusercontent.com/projectatomic/adb-atomic-developer-bundle/master/components/centos/centos-mesos-marathon-singlenode-setup/Vagrantfile > Vagrantfile
+
+
+       Refer: `README <../components/centos/centos-mesos-marathon-singlenode-setup/README.rst>`_
+
+
+  3. Start ADB
 
      ``vagrant up``
 
-  This will download the ADB and set it up to work with Docker, for use with host-based tools or via ``vagrant ssh``.
+  This will download ADB and set it up to work with the provider of choice,
+  for use with host-based tools or via ``vagrant ssh``.
 
-  You may wish to review the `Using the Atomic Developer Bundle`_ documentation before
-  starting the ADB, especially if you are using host-based tools.
+  **Note:** On Fedora and CentOS you may need to specify the virtualization
+  provider to use. For example, to use VirtualBox, the command would be
 
-.. _Using Custom Vagrantfiles for Specific Use Cases: https://github.com/projectatomic/adb-atomic-developer-bundle/blob/master/docs/using.rst#using-custom-vagrantfiles-for-specific-use-cases
-.. _Using the Atomic Developer Bundle: using.rst
-.. _Installation document: https://github.com/projectatomic/adb-atomic-developer-bundle/blob/master/docs/installing.rst
-.. _Docker Vagrantfile: https://github.com/projectatomic/adb-atomic-developer-bundle/blob/master/components/centos/centos-docker-base-setup/Vagrantfile
-.. _Kubernetes Vagrantfile: https://github.com/projectatomic/adb-atomic-developer-bundle/blob/master/components/centos/centos-k8s-singlenode-setup/Vagrantfile
-.. _OpenShift Origin Vagrantfile: https://github.com/projectatomic/adb-atomic-developer-bundle/blob/master/components/centos/centos-openshift-setup/Vagrantfile
-.. _Apache Mesos Marathon Vagrantfile: https://github.com/projectatomic/adb-atomic-developer-bundle/blob/master/components/centos/centos-mesos-marathon-singlenode-setup/Vagrantfile
+  ``vagrant up --provider virtualbox``
+
+
+  You may wish to review the `Using Atomic Developer Bundle`_ documentation before
+  starting ADB, especially if you are using host-based tools.
+
+.. _Using Atomic Developer Bundle: docs/using.rst
+.. _Docker: https://github.com/projectatomic/adb-atomic-developer-bundle/blob/master/components/centos/centos-docker-base-setup/Vagrantfile
+.. _Kubernetes: https://github.com/projectatomic/adb-atomic-developer-bundle/blob/master/components/centos/centos-k8s-singlenode-setup/Vagrantfile
+.. _OpenShift Origin: https://github.com/projectatomic/adb-atomic-developer-bundle/blob/master/components/centos/centos-openshift-setup/Vagrantfile
+.. _Apache Mesos Marathon: https://github.com/projectatomic/adb-atomic-developer-bundle/blob/master/components/centos/centos-mesos-marathon-singlenode-setup/Vagrantfile
 
 * Manually Downloading the Vagrant Box Image
 
@@ -246,6 +265,27 @@ There are two ways to download the ADB.
 
     # Add the image to vagrant
     $ vagrant box add adb <local path to the downloded image>
+
+-----------------------------------
+Setting up ADB behind an HTTP proxy
+-----------------------------------
+
+ADB can be set up behind a proxy server. You need to export the proxy server
+information in to the environment and then run ``vagrant up``.
+
+**Note:** Currently, only HTTP and HTTPS proxy servers are supported.
+
+For Linux, OS X and Windows Cygwin shell::
+
+  export PROXY="<proxy_server>:<port>"
+  export PROXY_USER="foo"
+  export PROXY_PASSWORD="mysecretpass"
+
+For Windows CMD or Powershell::
+
+  setx PROXY="<proxy_server>:<port>"
+  setx PROXY_USER="foo"
+  setx PROXY_PASSWORD="mysecretpass"
 
 At this point your Atomic Developer Bundle installation is complete. You can
 find `ADB Usage Information <using.rst>`_ in the documentation directory.

--- a/docs/using.rst
+++ b/docs/using.rst
@@ -7,20 +7,19 @@
    :backlinks: none
 
 =================================
-Using the Atomic Developer Bundle
+Using Atomic Developer Bundle
 =================================
 
 Principles
 ==========
 
-Consider the ADB to be ephemeral and do not store data in it long term. It is
+Consider ADB to be ephemeral and do not store data in it long term. It is
 recommended that you do the following:
 
 * Back up your code.
 * Use a source control system.
-* Mount your code into the box from your host system. The provided `custom Vagrantfile examples
-  <#using-custom-vagrantfiles-for-specific-use-cases>`_ already mount your home directory on the host
-  into the guest using `vagrant-sshfs <https://github.com/dustymabe/vagrant-sshfs/>`_.
+* Mount your code into the box from your host system. The `ADB Vagrantfiles <docs/installing.rst#4-download-the-adb>`_
+  already mount your home directory from the host into ADB using `vagrant-sshfs <https://github.com/dustymabe/vagrant-sshfs/>`_.
   Additional shares can also be defined. Refer to the `bi-directional folder sync
   section <#vagrant-bi-directional-folder-sync>`_ for more information.
 
@@ -28,71 +27,28 @@ Doing these things is beyond the scope of this document. Consult your Operating
 System manuals and the `Vagrant <http://vagrantup.com/>`_ website for more
 details.
 
-Starting the Vagrant Box
-========================
+Once you start ADB you can use it as:
 
-1. Initialize a new Vagrant environment by creating a Vagrantfile. You may find
-   it helpful to first create a new directory for use by this environment.
-   Create the Vagrantfile with this command:
+* a server resource for host-based tools (Eclipse/CLIs) or
+* a Linux virtual machine.
 
-   ``vagrant init <box name>``
+For a quick high level glimpse at ADB and how you can use it refer to the
+`Readme <https://github.com/projectatomic/adb-atomic-developer-bundle/blob/master/README.rst>`_.
+For detailed instructions on how to install ADB refer to the `Installation Document`_.
 
-   Box name is typically ``projectatomic/adb`` or whatever you named it when you
-   loaded it manually.
+.. _Installation Document: docs/installing.rst
 
-2. Edit the ``Vagrantfile`` to setup private networking. The private network is
-   used to expose ADB-based services, such as the docker daemon, to the host.
-   This is done by adding the following line in the ``Vagrant.configure``
-   section.
-
-   ``config.vm.network "private_network", type: "dhcp"``
-
-3. Start the Vagrant image with this command:
-
-   ``vagrant up``
-
-   **Note:** On Fedora and CentOS you may need to specify which virtualization
-   provider to use.  For example, to use VirtualBox, the command would be
-   ``vagrant up --provider virtualbox``
-
-Using Custom Vagrantfiles for Specific Use Cases
-================================================
-
-Custom Vagrant files are shipped for specific use cases. The README files
-contain useful documentation and a quickstart guide.
-
-* Docker for use with host-based tools, such as Eclipse and the docker CLI, or
-  via ``vagrant ssh``
-
-  * `Vagrantfile <../components/centos/centos-docker-base-setup/Vagrantfile>`_
-  * `README <../components/centos/centos-docker-base-setup/README.rst>`_
-
-* Kubernetes for use with host-based tools or via ``vagrant ssh``
-
-  * `Vagrantfile <../components/centos/centos-k8s-singlenode-setup/Vagrantfile>`_
-  * `README <../components/centos/centos-k8s-singlenode-setup/README.rst>`_
-
-* OpenShift Origin for use with host-based tools or via ``vagrant ssh``
-
-  * `Vagrantfile <../components/centos/centos-openshift-setup/Vagrantfile>`_
-  * `README <../components/centos/centos-openshift-setup/README.rst>`_
-
-* Apache Mesos Marathon for use with host-based tools or via ``vagrant ssh``
-
-  * `Vagrantfile <../components/centos/centos-mesos-marathon-singlenode-setup/Vagrantfile>`_
-  * `README <../components/centos/centos-mesos-marathon-singlenode-setup/README.rst>`_
-
-Using the ADB with Host-based Tools (Eclipse and CLIs)
+Using ADB with host-based tools (Eclipse and CLIs)
 ======================================================
 
 Many users have preferred development environments built from tools running on
 their development workstation. Even if these workstations are unable to run
 containers or container-components natively, the user may still want to use their
 preferred tools, editors, etc.
-The ADB can be used with these tools in a way that makes it seamless to interact
+ADB can be used with these tools in a way that makes it seamless to interact
 with files, preferred development tools, etc.
 
-The ADB exposes the docker daemon port and orchestrator access points so that tools
+ADB exposes the docker daemon port and orchestrator access points so that tools
 like Eclipse and various CLIs can interact with them. For security reasons,
 some ports, such as the docker daemon port, are TLS protected. Therefore some
 configuration is required before the service can be accessed.
@@ -114,22 +70,23 @@ To use ADB with Host-Based tools:
     config.servicemanager.services = 'openshift'
 
    **Note:**
-* Docker is a default service for the ADB and does not require any configuration to ensure it is started.
-  Additionally, the Red Hat Enterprise Linux Container Development Kit, which is
-  based on the Atomic Developer Bundle, automatically starts OpenShift as well.
-* You can enable multiple services as a comma separated list. For instance: `docker, openshift`.
 
-3. Enable any specific options for the services you have selected as:
+   * Docker is the default service for ADB and does not require any configuration to ensure it is started.
+     Red Hat Enterprise Linux Container Development Kit, which is based on
+     Atomic Developer Bundle, automatically starts OpenShift.
+   * You can use a comma-separated list to enable multiple services. For instance: `docker, openshift`.
 
-   For instance, in OpenShift, specific versions can be specified using the following variables:
+3. Enable the relevant option for the services you have selected in the Vagrantfile as:
+
+   For example, specific versions of OpenShift can be specified using the following variables:
 
    1. ``config.servicemanager.openshift_docker_registry = "docker.io"`` - Specifies the registry from where the service should be pulled.
    2. ``config.servicemanager.openshift_image_name = "openshift/origin"`` - Specifies the image to be used.
    3. ``config.servicemanager.openshift_image_tag = "v1.2.0"`` - Specifies the version of the image to be used.
 
-4. Start the ADB using ``vagrant up``. For details consult the `Installation documentation`_.
+4. Start ADB using ``vagrant up``. You will find detailed installation instructions in the `Installation document`_.
 
-.. _Installation documentation: https://github.com/projectatomic/adb-atomic-developer-bundle/blob/master/docs/installing.rst
+.. _Installation document: docs/installing.rst
 
 
 5. Configure the environment and download the required TLS certificates using
@@ -151,10 +108,10 @@ To use ADB with Host-Based tools:
    Setting these environment variables allows programs, such as Eclipse and the
    docker CLI to access the docker daemon.
 
-   **Note:** When the OpenShift service is running in the VM, a docker registry
-   is also started. This Docker registry can be consumed by external
-   tools such as Eclipse to push or pull images. The Docker registry url is exported
-   as a variable, and can be accessed as shown below::
+   **Note:** When the OpenShift service is running in the VM, a Docker registry
+   is also started. This Docker registry can be used by external tools such
+   as Eclipse to push or pull images. The Docker registry URL is exported as a
+   variable, and can be accessed by running the following command::
 
      $ vagrant service-manager env openshift
      # openshift env:
@@ -166,8 +123,7 @@ To use ADB with Host-Based tools:
 
 6. Begin developing.
 
-   If you do not have the docker CLI, you can use the ``install-cli`` command as
-   shown below::
+   If you do not have the docker CLI, you can use the ``install-cli`` command as::
 
      $ vagrant service-manager install-cli docker
 
@@ -200,29 +156,10 @@ To use ADB with Host-Based tools:
       variable in the "TCP Connection" field and the DOCKER_CERT_PATH in the
       "Authentication Section" Path.
 
-   5. You can test the connection and then accept the results. At this point, you are ready to use the ADB with Eclipse.
+   5. You can test the connection and then accept the results. At this point, you are ready to use ADB with Eclipse.
 
 .. _Docker Tooling: http://www.eclipse.org/community/eclipse_newsletter/2015/june/article3.php
       **Note:** Testing has been done with Eclipse 4.5.0.
-
-Using the ADB behind http proxy
-===============================
-
-ADB can be setup behind a proxy server. You need to export the proxy server information in to the environment and then run ``vagrant up``.
-
-**Note:** Currently, only HTTP and HTTPS proxy servers are supported.
-
-For GNU/Linux. OS X and Cygwin shell::
-    
-    export PROXY="<proxy_server>:<port>"
-    export PROXY_USER="foo"
-    export PROXY_PASSWORD="mysecretpass"
-
-For Windows CMD or Powershell::
-
-    setx PROXY="<proxy_server>:<port>"
-    setx PROXY_USER="foo"
-    setx PROXY_PASSWORD="mysecretpass"
 
 Using the box via SSH
 =====================
@@ -236,30 +173,33 @@ You are now at a shell prompt inside the Vagrant box. You can now execute
 commands and use the tools provided.
 
 You can use the `sccli <https://github.com/projectatomic/adb-utils/blob/master/README.rst>`_
-to manage the orchestration services inside of the ADB.
+to manage the orchestration services inside of ADB.
 ``sccli`` makes it easy to start and stop orchestration providers like Kubernetes
 or OpenShift.
 
 Using ``docker``
 ################
 
-The ADB provides a full container environment and runs both ``docker`` and
+ADB provides a full container environment and runs both ``docker`` and
 ``kubernetes``. All standard commands work, for example::
 
-   docker pull centos
+  ADB pull centos
    docker run -t -i centos /bin/bash
 
 Using Atomic App and Nulecule
 #############################
 
-Details on these projects can be found at these urls:
+Details on these projects can be found at these URLs:
 
 * Atomic App: https://github.com/projectatomic/atomicapp
 * Nulecule: https://github.com/projectatomic/nulecule
 
 The `helloapache`_ example can be used to test your installation.
 
-**Note:** Many Nulecule examples expect a working kubernetes environment. Use the `Vagrantfile <../components/centos/centos-k8s-singlenode-setup/Vagrantfile>`_ and refer the corresponding `README <../components/centos/centos-k8s-singlenode-setup/README.rst>`_ to set up a single node kubernetes environment.
+**Note:** Many Nulecule examples expect a working Kubernetes environment. Use
+the `Vagrantfile <../components/centos/centos-k8s-singlenode-setup/Vagrantfile>`_
+and refer the corresponding `README <../components/centos/centos-k8s-singlenode-setup/README.rst>`_
+to set up a single node Kubernetes environment.
 
 You can verify your environment by executing ``kubectl get nodes``. The
 expected output is::
@@ -307,7 +247,7 @@ There are also some other alternatives, which are, however, not yet properly tes
   * You can also use `vagrant-vbguest <https://github.com/dotless-de/vagrant-vbguest>`_ plugin to install Virtualbox guest additions in ADB Vagrant box.
 
 
-Some Useful Commands
+Some useful commands
 ====================
 * ``vagrant halt`` - Stop the vagrant box, temporarily:
 
@@ -322,9 +262,9 @@ Some Useful Commands
   Use ``vagrant status`` to check the status of ADB and to check which virtualization
   provider is being used and the status of the provider.
 
-* ``vagrant destroy`` - Destroy the Vagrant Box:
+* ``vagrant destroy`` - Destroy the Vagrant box:
 
   **Warning:**
-  Using ``vagrant destroy``, will destroy any data you have stored in the Vagrant
+  Using ``vagrant destroy`` will destroy any data you stored in the Vagrant
   box. You will not be able to restart this instance and will have to create a
   new one using ``vagrant up``.


### PR DESCRIPTION
1. Removed Starting the vagrant box and the Vagrantfile sections since mentioned in Readme and Installation docs where they are more relevant. This enables Usage Doc to solely focus on usage of ADB, once Installation is done.
2. Moved Installing ADB behind Proxy section to Installation doc.
3. Cleaned up references in Readme and Installation to vagrantfiles in the Usage doc.
4. Augmented the Vagrant plugin step with sshfs, Landrush and dependency related information.
