### PR TITLE
Fix #540 ~/.vagrant.d/Vagrantfile does not affect vagrant-registration

### DIFF
--- a/components/rhel/misc/rhel-k8s-singlenode-setup/Vagrantfile
+++ b/components/rhel/misc/rhel-k8s-singlenode-setup/Vagrantfile
@@ -23,9 +23,9 @@ Vagrant.configure(2) do |config|
   end
 
   # Proxy Information from environment
-  config.registration.proxy = PROXY = (ENV['PROXY'] || '')
-  config.registration.proxyUser = PROXY_USER = (ENV['PROXY_USER'] || '')
-  config.registration.proxyPassword = PROXY_PASSWORD = (ENV['PROXY_PASSWORD'] || '')
+  ENV['PROXY'] ? (config.registration.proxy = PROXY = ENV['PROXY']) : PROXY = ''
+  ENV['PROXY_USER'] ? (config.registration.proxyUser = PROXY_USER = ENV['PROXY_USER']) : PROXY_USER = ''
+  ENV['PROXY_PASSWORD'] ? (config.registration.proxyPassword = PROXY_PASSWORD = ENV['PROXY_PASSWORD']) : PROXY_PASSWORD = ''
 
   config.vm.provider "libvirt" do |libvirt, override|
     libvirt.driver = "kvm"

--- a/components/rhel/rhel-ose/Vagrantfile
+++ b/components/rhel/rhel-ose/Vagrantfile
@@ -25,7 +25,6 @@ unless errors.empty?
   fail Vagrant::Errors::VagrantError.new, msg
 end
 
-
 Vagrant.configure(2) do |config|
   config.vm.box = 'cdkv2'
 
@@ -43,7 +42,7 @@ Vagrant.configure(2) do |config|
     v.suspend_mode = "managedsave"
   end
 
-  config.vm.network "private_network", ip: "#{PUBLIC_ADDRESS}" 
+  config.vm.network "private_network", ip: "#{PUBLIC_ADDRESS}"
 
   # vagrant-registration
   if ENV.has_key?('SUB_USERNAME') && ENV.has_key?('SUB_PASSWORD')
@@ -52,9 +51,9 @@ Vagrant.configure(2) do |config|
   end
 
   # Proxy Information from environment
-  config.registration.proxy = PROXY = (ENV['PROXY'] || '')
-  config.registration.proxyUser = PROXY_USER = (ENV['PROXY_USER'] || '')
-  config.registration.proxyPassword = PROXY_PASSWORD = (ENV['PROXY_PASSWORD'] || '')
+  ENV['PROXY'] ? (config.registration.proxy = PROXY = ENV['PROXY']) : PROXY = ''
+  ENV['PROXY_USER'] ? (config.registration.proxyUser = PROXY_USER = ENV['PROXY_USER']) : PROXY_USER = ''
+  ENV['PROXY_PASSWORD'] ? (config.registration.proxyPassword = PROXY_PASSWORD = ENV['PROXY_PASSWORD']) : PROXY_PASSWORD = ''
 
   # vagrant-sshfs
   config.vm.synced_folder '.', '/vagrant', disabled: true


### PR DESCRIPTION
Fix #540 
- IF there is no proxy provided through environment variables then
  don't invoke the "config.registration.*" calls to set them empty
  as it is changing the default vagrant behavior of getting those
  configurations from other Vagrantfile like ~/.vagrant.d/Vagrantfile
- Also, the current Vagrantfile assumes that proxy variables will be passed through environment variables. 
  However, one can change the Vagrantfile to put hard coded entries as below which is not at all recommended.

```
# check proxy_url, proxy_user, proxy_password

config.registration.proxy = PROXY = (ENV['PROXY'] || 'proxy_url' )
config.registration.proxyUser = PROXY_USER = (ENV['PROXY_USER'] || 'proxy_user')
config.registration.proxyPassword = PROXY_PASSWORD = (ENV['PROXY_PASSWORD'] || 'proxy_password')
```

**NOTE:** There will not be such way to put hard coded entries in Vagrantfile through this PR implementation. 
