### PR TITLE
Enable live-rendering of TOC in GitHub for adoc files

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -1,14 +1,18 @@
 = Atomic Developer Bundle
 :toc:
-
-[[what-is-atomic-developer-bundle-adb]]
-== What is Atomic Developer Bundle (ADB)?
+:toc-placement!:
 
 Atomic Developer Bundle (ADB) is a prepackaged development environment
 filled with production-grade, pre-configured tools, that makes container
 developers' lives easier. ADB supports the development of
 multi-container applications against different technologies and
 orchestrators while providing a path that promotes best practices.
+
+'''
+toc::[]
+'''
+
+== Advantage of ADB
 
 As a container developer, you want to use ADB for these reasons:
 

--- a/docs/installing.adoc
+++ b/docs/installing.adoc
@@ -1,6 +1,12 @@
 = Installing Atomic Developer Bundle
 :toc:
+:toc-placement!:
 
+This document describes how to install ADB and required dependencies.
+
+'''
+toc::[]
+'''
 
 [[install-a-virtualization-provider]]
 == Install a virtualization provider

--- a/docs/updating.adoc
+++ b/docs/updating.adoc
@@ -1,12 +1,15 @@
 = Updating Atomic Developer Bundle to the latest version
 :toc:
+:toc-placement!:
 
 Depending on your implementation of the ADB, you might be able to
 directly update your Vagrant box. In some cases, you will need to
 perform a clean installation or follow additional steps to complete the
 update.
 
+'''
 toc::[]
+'''
 
 [[prerequisites]]
 == Prerequisites

--- a/docs/using.adoc
+++ b/docs/using.adoc
@@ -1,5 +1,12 @@
 = Using Atomic Developer Bundle
 :toc:
+:toc-placement!:
+
+This document describes how to configure and use ADB and its related plugins.
+
+'''
+toc::[]
+'''
 
 [[principles]]
 == Principles


### PR DESCRIPTION
Fixes #556 

This PR aims to fix the problem where the TOC wasn't rendered in GitHub, even though in local asciidoctor build the TOC was rendered correctly. To fix this, I copied the tagging of the TOC from VSM readme file and restructured the top of the files to include an intro paragraph after the h1, with the TOC appearing after that paragraph.

Affected files:
- README.adoc
  -installing.adoc
  -using.adoc
  -updating.adoc

The rest of the doc files are small and don't require a TOC.
