### PR TITLE
Fix #545 Make box name configurable in Vagrantfile

### DIFF
--- a/components/centos/centos-docker-base-setup/Vagrantfile
+++ b/components/centos/centos-docker-base-setup/Vagrantfile
@@ -1,7 +1,8 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
 
-# Vagrant file for libvirt/kvm and virtualbox provider
+BOX_NAME = 'projectatomic/adb'
+
 REQUIRED_PLUGINS = %w(vagrant-service-manager vagrant-sshfs)
 errors = []
 
@@ -16,7 +17,8 @@ unless errors.empty?
 end
 
 Vagrant.configure(2) do |config|
-  config.vm.box = "projectatomic/adb"
+  # Use environment variable BOX or default 'projectatomic/adb'
+  config.vm.box = (ENV.key?('BOX') ? (ENV['BOX'].empty? ? BOX_NAME : ENV['BOX']) : BOX_NAME)
 
   # Setup a DHCP based private network
   config.vm.network "private_network", type: "dhcp"

--- a/components/centos/centos-k8s-singlenode-setup/Vagrantfile
+++ b/components/centos/centos-k8s-singlenode-setup/Vagrantfile
@@ -1,6 +1,8 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
 
+BOX_NAME = 'projectatomic/adb'
+
 REQUIRED_PLUGINS = %w(vagrant-service-manager vagrant-sshfs)
 errors = []
 
@@ -16,7 +18,8 @@ end
 
 # Vagrantfile for single node k8s setup
 Vagrant.configure(2) do |config|
-  config.vm.box = "projectatomic/adb"
+  # Use environment variable BOX or default 'projectatomic/adb'
+  config.vm.box = (ENV.key?('BOX') ? (ENV['BOX'].empty? ? BOX_NAME : ENV['BOX']) : BOX_NAME)
 
   config.vm.provider "libvirt" do |libvirt, override|
     libvirt.driver = "kvm"

--- a/components/centos/centos-mesos-marathon-singlenode-setup/Vagrantfile
+++ b/components/centos/centos-mesos-marathon-singlenode-setup/Vagrantfile
@@ -1,6 +1,7 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
 
+BOX_NAME = 'projectatomic/adb'
 
 IP_ADDRESS="10.2.2.2"
 
@@ -18,7 +19,8 @@ unless errors.empty?
 end
 
 Vagrant.configure("2") do |config|
-	config.vm.box = "projectatomic/adb"
+  # Use environment variable BOX or default 'projectatomic/adb'
+  config.vm.box = (ENV.key?('BOX') ? (ENV['BOX'].empty? ? BOX_NAME : ENV['BOX']) : BOX_NAME)
 
   config.vm.provider "virtualbox" do |v, override|
     v.memory = 2048
@@ -76,27 +78,27 @@ Vagrant.configure("2") do |config|
                     - mesos-slave
 
               - name: Configure IP address for mesos-slave
-                copy: 
+                copy:
                     content: '{{ ip_address }}'
                     dest: /etc/mesos-slave/ip
 
               - name: Configure Port Ranges for mesos-slave
-                copy: 
+                copy:
                     content: 'ports:[1024-32000]'
                     dest: /etc/mesos-slave/resources
 
               - name: Increase timeout to account for docker pull delay
-                copy: 
+                copy:
                     content: '5mins'
                     dest: /etc/mesos-slave/executor_registration_timeout
 
               - name: Add docker containerizer
                 copy:
-                    content: 'docker,mesos' 
+                    content: 'docker,mesos'
                     dest: /etc/mesos-slave/containerizers
 
               - name: Configure IP address for Marathon
-                copy: 
+                copy:
                     content: '{{ ip_address }}'
                     dest: /etc/marathon/conf/hostname
 
@@ -106,8 +108,8 @@ Vagrant.configure("2") do |config|
               - name: Installing zookeeper, mesos, marathon, docker, git, atomicapp
                 yum: name={{item}} state=present
                 with_items:
-                    - mesosphere-zookeeper 
-                    - mesos 
+                    - mesosphere-zookeeper
+                    - mesos
                     - marathon
                     - docker
                     - git

--- a/components/centos/centos-openshift-setup/Vagrantfile
+++ b/components/centos/centos-openshift-setup/Vagrantfile
@@ -1,6 +1,8 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
 
+BOX_NAME = 'projectatomic/adb'
+
 # The Docker registry from where we pull the OpenShift Docker image
 DOCKER_REGISTRY="docker.io"
 
@@ -39,7 +41,9 @@ end
 # <https://docs.openshift.org/latest/welcome/index.html>`_.
 
 Vagrant.configure(2) do |config|
-  config.vm.box = 'projectatomic/adb'
+  # Use environment variable BOX or default 'projectatomic/adb'
+  config.vm.box = (ENV.key?('BOX') ? (ENV['BOX'].empty? ? BOX_NAME : ENV['BOX']) : BOX_NAME)
+
   config.vm.hostname = HOSTNAME
 
   config.vm.provider "virtualbox" do |v, override|

--- a/components/rhel/misc/rhel-k8s-singlenode-setup/README.adoc
+++ b/components/rhel/misc/rhel-k8s-singlenode-setup/README.adoc
@@ -24,15 +24,29 @@ toc::[]
 ----
 $ mkdir directory && cd directory
 ----
-.  Get the latest CDK box and add it to Vagrant. You can download the CDK
-and find further information about CDK
-http://developers.redhat.com/products/cdk/overview/[here]. For detailed instructions on how to install CDK refer to the https://access.redhat.com/documentation/en/red-hat-container-development-kit/2.2/paged/installation-guide[CDK Installation Guide].
+
+.  Get the latest CDK box using Developer Subscription. You can download
+the CDK and find further information about CDK
+http://developers.redhat.com/products/cdk/overview/[here]. For detailed instructions on how to install CDK refer to the
+https://access.redhat.com/documentation/en/red-hat-container-development-kit/2.2/paged/installation-guide[CDK Installation Guide].
 
 +
-NOTE: The name you assign to the box using the --name parameter in the `$ vagrant box add --name cdkv2 \
-  ~/Downloads/rhel-cdk-kubernetes-7.2-*.x86_64.vagrant-libvirt.box` command, must correspond to the name used by the Vagrantfile used to initialize the box. By default, this is cdkv2 for the Vagrantfiles provided with Container Development Kit.
+[NOTE]
+====
+If you want to use a customized name for the box, you need to:
 
-.  Download the vagrantfile.
+* Specify your `<box-name>` in place of `cdkv2` as in:
+----
+$ vagrant box add --name <box-name> <Downloaded Folder>/rhel-cdk-kubernetes-7.2-*.x86_64.vagrant-libvirt.box
+----
+* Add the `<box-name>` as the value of the `BOX` environment variable with the following command:
+----
+export BOX=<box-name>
+----
+====
++
+
+.  Download the Vagrantfile.
 +
 ----
 $ curl -sL https://raw.githubusercontent.com/projectatomic/adb-atomic-developer-bundle/master/components/rhel/misc/rhel-k8s-singlenode-setup/Vagrantfile > Vagrantfile

--- a/components/rhel/misc/rhel-k8s-singlenode-setup/Vagrantfile
+++ b/components/rhel/misc/rhel-k8s-singlenode-setup/Vagrantfile
@@ -1,5 +1,7 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
+BOX_NAME = 'cdkv2'
+
 REQUIRED_PLUGINS = %w(vagrant-service-manager vagrant-registration vagrant-sshfs)
 errors = []
 
@@ -13,9 +15,11 @@ unless errors.empty?
   fail Vagrant::Errors::VagrantError.new, msg
 end
 
+
 # Vagrantfile for single node k8s setup
 Vagrant.configure(2) do |config|
-  config.vm.box = "cdkv2"
+  # Use environment variable BOX or default 'cdkv2'
+  config.vm.box = (ENV.key?('BOX') ? (ENV['BOX'].empty? ? BOX_NAME : ENV['BOX']) : BOX_NAME)
 
   if ENV.has_key?('SUB_USERNAME') && ENV.has_key?('SUB_PASSWORD')
     config.registration.username = ENV['SUB_USERNAME']

--- a/components/rhel/rhel-ose/README.adoc
+++ b/components/rhel/rhel-ose/README.adoc
@@ -24,14 +24,32 @@ toc::[]
 $ mkdir directory && cd directory
 ----
 
-.  Get the latest CDK box (using Developer Subscription). You can download
+.  Get the latest CDK box using Developer Subscription. You can download
 the CDK and find further information about CDK
 http://developers.redhat.com/products/cdk/overview/[here]. For detailed instructions on how to install CDK refer to the
 https://access.redhat.com/documentation/en/red-hat-container-development-kit/2.2/paged/installation-guide[CDK Installation Guide].
 
+. Add the box to Vagrant with the following command:
 +
-NOTE: The name you assign to the box using the --name parameter in the `$ vagrant box add --name cdkv2 \
-  ~/Downloads/rhel-cdk-kubernetes-7.2-*.x86_64.vagrant-libvirt.box` command, must correspond to the name used by the Vagrantfile used to initialize the box. By default, this is cdkv2 for the Vagrantfiles provided with Container Development Kit.
+----
+$ vagrant box add --name cdkv2 <Downloaded Folder>/rhel-cdk-kubernetes-7.2-*.x86_64.vagrant-libvirt.box
+----
+
++
+[NOTE]
+====
+If you want to use a customized name for the box, you need to:
+
+* Specify your `<box-name>` in place of `cdkv2` as in:
+----
+$ vagrant box add --name <box-name> <Downloaded Folder>/rhel-cdk-kubernetes-7.2-*.x86_64.vagrant-libvirt.box
+----
+* Add the `<box-name>` as the value of the `BOX` environment variable with the following command:
+----
+export BOX=<box-name>
+----
+====
++
 
 .  Download the Vagrantfile.
 +

--- a/components/rhel/rhel-ose/Vagrantfile
+++ b/components/rhel/rhel-ose/Vagrantfile
@@ -29,7 +29,8 @@ unless errors.empty?
 end
 
 Vagrant.configure(2) do |config|
-  config.vm.box = 'cdkv2'
+  # Use environment variable BOX or default 'cdkv2'
+  config.vm.box = (ENV.key?('BOX') ? (ENV['BOX'].empty? ? BOX_NAME : ENV['BOX']) : BOX_NAME)
 
   config.vm.provider "virtualbox" do |v, override|
     v.memory = VM_MEMORY

--- a/docs/installing.adoc
+++ b/docs/installing.adoc
@@ -275,27 +275,39 @@ You may wish to review the link:docs/using.adoc[Using Atomic Developer
 Bundle] documentation before starting ADB, especially if you are using
 host-based tools.
 
-=== Manually Download the Vagrant Box Image
+=== Manually Download the Vagrant Box
 
 Alternatively, you can manually download the vagrant box from
 http://cloud.centos.org/centos/7/atomic/images/[cloud.centos.org] using
 your web browser or curl. For example:
 
 ----
-# To get the libvirt image
-$ wget http://cloud.centos.org/centos/7/atomic/images/AtomicDeveloperBundle-<latest>.box
+# To get the libvirt box
+$ wget http://cloud.centos.org/centos/7/atomic/images/AtomicDeveloperBundle-<version>-CentOS7-LibVirt.box
 
-# To get the virtual box image
-$ wget http://cloud.centos.org/centos/7/atomic/images/AtomicDeveloperBundle-<latest>.box
+# To get the virtualbox box
+$ wget http://cloud.centos.org/centos/7/atomic/images/AtomicDeveloperBundle-<version>-CentOS7-VirtualBox.box
 ----
 
-After you download the image, you can add it to `vagrant` with
-this command:
+After you download the box, you can add it to `vagrant` with following command:
+----
+$ vagrant box add projectatomic/adb <local path to the downloaded box>
+----
 
+[NOTE]
+====
+If you want to use a customized name for the box, you need to:
+
+* Specify your `<box-name>` in place of `projectatomic/adb` as in:
 ----
-# Add the image to vagrant
-$ vagrant box add adb <local path to the downloded image>
+$ vagrant box add <box-name> <local path to the downloaded box>
 ----
+* Add the `<box-name>` as the value of the `BOX` environment variable with the following command:
+----
+export BOX=<box-name>
+----
+====
+
 
 [[set-up-adb-behind-an-http-proxy]]
 == Step 6. (Optional) Set up ADB behind an HTTP proxy


### PR DESCRIPTION
Fix #545 

Now, one can use any box name as:

```
BOX=<box-name> vagrant up
or
export BOX=<box-name>
vagrant up
```
