### PR TITLE
Formatting fixes and style convention adjustments

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -165,9 +165,11 @@ document].
 To download ADB and set up a provider-specific container development
 environment:
 +
-.. Create a directory for the Vagrant box
+.. Create a directory for the Vagrant box.
 +
-`$ mkdir directory && cd directory`
+----
+$ mkdir directory && cd directory
+----
 
 .. Download any of the following vagrantfiles, to configure the
 development environment you need.
@@ -175,32 +177,32 @@ development environment you need.
 https://github.com/projectatomic/adb-atomic-developer-bundle/blob/master/components/centos/centos-docker-base-setup/Vagrantfile[Docker
 specific container development environment] use:
 +
-....
+----
 $ curl -sL https://raw.githubusercontent.com/projectatomic/adb-atomic-developer-bundle/master/components/centos/centos-docker-base-setup/Vagrantfile > Vagrantfile
-....
+----
 * To configure a
 https://github.com/projectatomic/adb-atomic-developer-bundle/blob/master/components/centos/centos-k8s-singlenode-setup/Vagrantfile[Kubernetes
 specific container development environment] use:
 +
-....
+----
 $ curl -sL https://raw.githubusercontent.com/projectatomic/adb-atomic-developer-bundle/master/components/centos/centos-k8s-singlenode-setup/Vagrantfile > Vagrantfile
-....
+----
 * To configure an
 https://github.com/projectatomic/adb-atomic-developer-bundle/blob/master/components/centos/centos-openshift-setup/Vagrantfile[OpenShift
 Origin specific container development environment] use:
 +
-....
+----
 $ curl -sL https://raw.githubusercontent.com/projectatomic/adb-atomic-developer-bundle/master/components/centos/centos-openshift-setup/Vagrantfile > Vagrantfile
-....
+----
 * To configure an
 https://github.com/projectatomic/adb-atomic-developer-bundle/blob/master/components/centos/centos-mesos-marathon-singlenode-setup/Vagrantfile[Apache
 Mesos Marathon specific container development environment] use:
 +
-....
+----
 $ curl -sL https://raw.githubusercontent.com/projectatomic/adb-atomic-developer-bundle/master/components/centos/centos-mesos-marathon-singlenode-setup/Vagrantfile > Vagrantfile
-....
+----
 
-. Start ADB:
+. Start ADB.
 +
 ----
 vagrant up
@@ -245,6 +247,8 @@ specific build requirements that are not enabled in those boxes.
 * link:docs/installing.adoc[Installing ADB]
 * link:docs/using.adoc[How to use ADB]
 ** link:docs/cockpit.adoc[Using Cockpit with ADB]
+* link:docs/staging.adoc[Staging your application]
+* link:docs/troubleshooting.adoc[Troubleshooting ADB]
 * link:docs/updating.adoc[Updating ADB]
 * link:docs/building.adoc[Building the Vagrant box] for Developers
 
@@ -265,6 +269,9 @@ Documentation is written using
 http://asciidoctor.org/docs/asciidoc-syntax-quick-reference/[ASCIIDoc].
 You can create and edit content in your favorite text editor with
 http://asciidoctor.org/docs/editing-asciidoc-with-live-preview/[live preview].
+
+For detailed information about contributing to the projects,
+see link:CONTRIBUTING.adoc[how to contribute].
 
 == Additional online resources
 

--- a/components/centos/centos-docker-base-setup/README.adoc
+++ b/components/centos/centos-docker-base-setup/README.adoc
@@ -1,12 +1,12 @@
 = Vagrantfile: CentOS Docker Base
 :toc:
 
-This Vagrantfile is the default suggested configuration for the ADB.
+This Vagrantfile is the default suggested configuration for ADB.
 This file sets up private networking that will be used to expose the
 docker daemon to the host. This Vagrantfile is useful for anyone using
 host-based tools, such as the
 https://wiki.eclipse.org/Linux_Tools_Project/Docker_Tooling[Eclipse
-docker tooling] or the docker CLI, with the ADB.
+docker tooling] or the docker CLI, with ADB.
 
 [[quickstart]]
 == Quickstart

--- a/components/centos/centos-k8s-singlenode-setup/README.adoc
+++ b/components/centos/centos-k8s-singlenode-setup/README.adoc
@@ -1,7 +1,7 @@
 = Vagrantfile: CentOS Single-Node Kubernetes
 :toc:
 
-This Vagrantfile is the suggested configuration for using the ADB with
+This Vagrantfile is the suggested configuration for using ADB with
 Kubernetes. This file sets up private networking that will be used to
 expose the docker daemon and kubernetes to the host. This file also sets
 up a single node Kubernetes instance where the master and node are on
@@ -9,7 +9,7 @@ the same machine.
 
 This Vagrantfile is useful for anyone using host-based tools, such as
 the https://wiki.eclipse.org/Linux_Tools_Project/Docker_Tooling[Eclipse
-docker tooling] or the kubernetes and docker CLIs, with the ADB.
+docker tooling] or the kubernetes and docker CLIs, with ADB.
 
 [[quickstart]]
 == Quickstart
@@ -45,8 +45,8 @@ Atomic Developer Bundle].
 You may wish to `vagrant ssh` into ADB and verify that Kubernetes is
 setup using the `kubectl` CLI as follows:
 
-....
+----
 $ kubectl get nodes
 NAME        LABELS                             STATUS
 127.0.0.1   kubernetes.io/hostname=127.0.0.1   Ready
-....
+----

--- a/components/centos/centos-openshift-setup/README.adoc
+++ b/components/centos/centos-openshift-setup/README.adoc
@@ -3,7 +3,7 @@
 
 This Vagrantfile:
 
-* Sets up the ADB for development with OpenShift
+* Sets up ADB for development with OpenShift
 * Sets up private networking that is used to expose various services to
 the host
 * Provisions an instance of http://www.openshift.org//[OpenShift Origin]

--- a/components/rhel/misc/rhel-k8s-singlenode-setup/README.adoc
+++ b/components/rhel/misc/rhel-k8s-singlenode-setup/README.adoc
@@ -52,8 +52,8 @@ $ vagrant up
 You may wish to `vagrant ssh` into the CDK and verify that Kubernetes is
 setup using the `kubectl` CLI as follows:
 
-....
+----
 $ kubectl get nodes
 NAME        LABELS                             STATUS
 127.0.0.1   kubernetes.io/hostname=127.0.0.1   Ready
-....
+----

--- a/docs/building.adoc
+++ b/docs/building.adoc
@@ -1,7 +1,7 @@
 = Building the ADB Vagrant Box
 
 The Vagrant box is based on CentOS 7. It is built using the latest
-packages from CentOS core. Some components of the ADB will be delivered
+packages from CentOS core. Some components of ADB will be delivered
 in containers and will use code drawn from upstream projects to add
 newer features. Today, the fully built box does not include any docker image. +
 The box can be built using the CentOS powered

--- a/docs/cockpit.adoc
+++ b/docs/cockpit.adoc
@@ -23,7 +23,7 @@ the host you are running ADB on.
 +
 `$ vagrant ssh -c "sudo systemctl start cockpit"`
 
-.  Determine the IP Address of the ADB
+.  Determine the IP Address of ADB
 +
 `$ vagrant service-manager box ip`
 
@@ -34,6 +34,6 @@ the host you are running ADB on.
 You may need to accept a TLS certificate as cockpit generates a
 self-signed SSL certificate.
 
-.  You may now use cockpit on the ADB. Two users are available by
+.  You may now use cockpit on ADB. Two users are available by
 default. The username for a standard user is `vagrant` the password is
 `vagrant`. The root user has a password of `vagrant`.

--- a/docs/installing.adoc
+++ b/docs/installing.adoc
@@ -17,8 +17,8 @@ Libvirt.
 The following virtualization providers are suggested for the respective
 operating systems:
 
-* Microsoft Windows and Mac OS X
-+
+=== Microsoft Windows and Mac OS X
+
 The suggested virtualization provider for Microsoft Windows and Mac OS X
 is https://www.virtualbox.org[VirtualBox]. Installation instructions are
 available https://www.virtualbox.org/manual/UserManual.html[online].
@@ -26,8 +26,8 @@ While the latest stable shipping release should work, the majority of
 testing has been done with version 5.0.0 on Mac OS X and 5.0.8 on
 Microsoft Windows.
 
-* Fedora
-+
+=== Fedora
+
 Two different virtualization providers are supported on Linux;
 https://www.virtualbox.org[VirtualBox] and http://libvirt.org/[libvirt].
 The choice as to which to use should be driven by your preferences and
@@ -35,8 +35,8 @@ environmental concerns and is outside of the scope of this document.
 Both will work equally well in their default configuration. You may wish
 to read the section on file synchronization in the
 https://github.com/projectatomic/adb-atomic-developer-bundle/blob/master/docs/using.adoc[Using ADB documentation] when making this decision.
-+
-** VirtualBox installation instructions are available
+
+* VirtualBox installation instructions are available
 https://www.virtualbox.org/manual/ch02.html#startingvboxonlinux[online
 at the VirtualBox website]. Testing has been done with versions 4.3.34
 and 5.0.0.
@@ -53,13 +53,14 @@ $ sudo /etc/init.d/vboxdrv setup
 +
 While the latest stable release should work, the majority of testing has
 been done with version 4.3.30.
-** Installing libvirt dependencies can be skipped as they are
+
+* Installing libvirt dependencies can be skipped as they are
 automatically installed together with the `vagrant-libvirt` package.
 Testing has been done with libvirt version 1.2.18 and vagrant-libvirt
 version 0.0.32.
 
-* CentOS
-+
+=== CentOS
+
 Two different virtualization providers are supported on Linux;
 https://www.virtualbox.org[VirtualBox] and http://libvirt.org/[libvirt].
 The choice as to which to use should be driven by your preferences and
@@ -67,8 +68,8 @@ environmental concerns and is outside of the scope of this document.
 Both will work equally well in their default configuration. You may wish
 to read the section onfile synchronization in the
 https://github.com/projectatomic/adb-atomic-developer-bundle/blob/master/docs/using.adoc[Using ADB documentation] when making this decision.
-+
-** VirtualBox installation instructions are available
+
+* VirtualBox installation instructions are available
 https://www.virtualbox.org/manual/ch02.html#startingvboxonlinux[online
 at the VirtualBox website].
 https://wiki.centos.org/HowTos/Virtualization/VirtualBox[CentOS specific
@@ -87,39 +88,44 @@ $ sudo mv virtualbox.repo /etc/yum.repos.d/
 $ sudo yum -y install VirtualBox-4.3
 $ sudo /etc/init.d/vboxdrv setup
 ....
-** Installing libvirt dependencies can be skipped as they are
+
+* Installing libvirt dependencies can be skipped as they are
 automatically installed together with the CentOS software collections
 build.
 
 [[install-vagrant]]
 == Step 2. Install Vagrant
 
-* Microsoft Windows
-1.  Follow the directions at
+This section includes installation instructions according to your operating system.
+
+=== Microsoft Windows
+
+.  Follow the directions at
 https://docs.vagrantup.com/v2/installation/index.html[vagrantup.com].
 Testing has been done with version 1.7.4.
-2.  Install an `ssh` client. Two good options are:
-** https://cygwin.com/install.html[Cygwin]
-** http://www.mingw.org/[mingw]
-+
-Please note, Putty is not recommended as it doesn't currently interface with Vagrant.
 
-* Mac OS X
-+
+.  Install an `ssh` client. Two good options are:
+* https://cygwin.com/install.html[Cygwin]
+* http://www.mingw.org/[mingw]
+
+NOTE: Putty is not recommended as it doesn't currently interface with Vagrant.
+
+=== Mac OS X
+
 Follow the directions at
 https://docs.vagrantup.com/v2/installation/index.html[vagrantup.com].
 Testing has been done with version 1.7.4.
 
-* Fedora 23/24
-+
+=== Fedora 23/24
+
 Testing has been done with version 1.7.2.
-+
-** To install Vagrant with VirtualBox in Fedora 23/24:
+
+* To install Vagrant with VirtualBox in Fedora 23/24:
 +
 ....
 $ sudo dnf install -y vagrant
 ....
-** To install Vagrant with libvirt in Fedora 23/24:
+* To install Vagrant with libvirt in Fedora 23/24:
 +
 ....
 $ sudo dnf -y install vagrant-libvirt
@@ -133,29 +139,29 @@ $ sudo systemctl enable libvirtd
 +
 This would install both Vagrant and Libvirt.
 
-* CentOS
-+
+=== CentOS
+
 Vagrant packages are not available directly in CentOS core. However,
 they are available through official CentOS
 http://softwarecollections.org[Software Collections] builds.
-+
-Here are the commands to get Vagrant in CentOS:
-+
-....
+
+Run the following commands to get Vagrant in CentOS:
+
+----
 $ sudo yum -y install centos-release-scl
 $ sudo yum -y install sclo-vagrant1
 $ sudo scl enable sclo-vagrant1 bash
-....
-+
-To add libvirt support use this:
-+
-....
+----
+
+To add libvirt support, also run the following commands:
+
+----
 # Start libvirtd
 $ sudo systemctl start libvirtd
 
 # Set libvirtd to start automatically on system boot
 $ sudo systemctl enable libvirtd
-....
+----
 
 [[install-additional-dependencies]]
 == Step 3. Install additional dependencies
@@ -163,14 +169,14 @@ $ sudo systemctl enable libvirtd
 For some operating systems, you might need to install additional
 dependencies before you install the Vagrant plugins.
 
-* Fedora 23/24
-+
+=== Fedora 23/24
+
 Run the following commands to install the additional dependencies:
-+
-....
+
+----
 $ sudo dnf install @'Development Tools'
 $ sudo dnf install rpm-build zlib-devel ruby-devel gcc-c++
-....
+----
 
 [[install-vagrant-plugins]]
 == Step 4. Install Vagrant plugins
@@ -180,68 +186,68 @@ https://github.com/projectatomic/vagrant-service-manager[vagrant-service-manager
 https://github.com/dustymabe/vagrant-sshfs[vagrant-sshfs], and
 https://github.com/vagrant-landrush/landrush[landrush] plugins:
 
-....
+----
 $ vagrant plugin install vagrant-service-manager
 $ vagrant plugin install vagrant-sshfs
 $ vagrant plugin install landrush
-....
+----
 
 [[download-adb]]
 == Step 5. Download ADB
 
 There are two ways to download ADB.
 
-* Vagrantfiles Initiated Download
-+
+=== Download preconfigured Vagrantfiles
+
 The ADB project provides customized Vagrantfiles, which will download
 ADB and automatically set up provider-specific container development
 environments. They are listed below and more details are available in
 their respective Readmes.
-+
+
 To download ADB and set up a provider-specific container development
 environment:
-+
+
 .  Create a directory for the Vagrant box
 +
 `$ mkdir directory && cd directory`
 .  Download any of the following vagrantfiles, to configure the
 development environment you need.
-** To configure a
+* To configure a
 https://github.com/projectatomic/adb-atomic-developer-bundle/blob/master/components/centos/centos-docker-base-setup/Vagrantfile[Docker]
 specific container development environment use:
 +
-....
+----
 $ curl -sL https://raw.githubusercontent.com/projectatomic/adb-atomic-developer-bundle/master/components/centos/centos-docker-base-setup/Vagrantfile > Vagrantfile
-....
+----
 +
 Refer:
 link:../components/centos/centos-docker-base-setup/README.adoc[README]
-** To configure a
+* To configure a
 https://github.com/projectatomic/adb-atomic-developer-bundle/blob/master/components/centos/centos-k8s-singlenode-setup/Vagrantfile[Kubernetes]
 specific container development environment use:
 +
-....
+----
 $ curl -sL https://raw.githubusercontent.com/projectatomic/adb-atomic-developer-bundle/master/components/centos/centos-k8s-singlenode-setup/Vagrantfile > Vagrantfile
-....
+----
 +
 Refer:
 link:../components/centos/centos-k8s-singlenode-setup/README.adoc[README]
-** To configure an https://github.com/projectatomic/adb-atomic-developer-bundle/blob/master/components/centos/centos-openshift-setup/Vagrantfile[OpenShift Origin] specific container development environment
+* To configure an https://github.com/projectatomic/adb-atomic-developer-bundle/blob/master/components/centos/centos-openshift-setup/Vagrantfile[OpenShift Origin] specific container development environment
 use:
 +
-....
+----
 $ curl -sL https://raw.githubusercontent.com/projectatomic/adb-atomic-developer-bundle/master/components/centos/centos-openshift-setup/Vagrantfile > Vagrantfile
-....
+----
 +
 Refer:
 link:../components/centos/centos-openshift-setup/README.adoc[README]
-** To configure an
+* To configure an
 https://github.com/projectatomic/adb-atomic-developer-bundle/blob/master/components/centos/centos-mesos-marathon-singlenode-setup/Vagrantfile[Apache
 Mesos Marathon] specific container development environment use:
 +
-....
+----
 $ curl -sL https://raw.githubusercontent.com/projectatomic/adb-atomic-developer-bundle/master/components/centos/centos-mesos-marathon-singlenode-setup/Vagrantfile > Vagrantfile
-....
+----
 +
 Refer:
 link:../components/centos/centos-mesos-marathon-singlenode-setup/README.adoc[README]
@@ -259,6 +265,7 @@ choice, for use with host-based tools or via `vagrant ssh`.
 ====
 On Fedora and CentOS you may need to specify the virtualization
 provider to use. For example, to use VirtualBox, the command would be:
+
 ----
 $ vagrant up --provider virtualbox
 ----
@@ -268,27 +275,27 @@ You may wish to review the link:docs/using.adoc[Using Atomic Developer
 Bundle] documentation before starting ADB, especially if you are using
 host-based tools.
 
-* Manually Downloading the Vagrant Box Image
-+
+=== Manually Download the Vagrant Box Image
+
 Alternatively, you can manually download the vagrant box from
 http://cloud.centos.org/centos/7/atomic/images/[cloud.centos.org] using
 your web browser or curl. For example:
-+
-....
+
+----
 # To get the libvirt image
 $ wget http://cloud.centos.org/centos/7/atomic/images/AtomicDeveloperBundle-<latest>.box
 
 # To get the virtual box image
 $ wget http://cloud.centos.org/centos/7/atomic/images/AtomicDeveloperBundle-<latest>.box
-....
-+
-Once you have downloaded the image, you can add it to `vagrant` with
+----
+
+After you download the image, you can add it to `vagrant` with
 this command:
-+
-....
+
+----
 # Add the image to vagrant
 $ vagrant box add adb <local path to the downloded image>
-....
+----
 
 [[set-up-adb-behind-an-http-proxy]]
 == Step 6. (Optional) Set up ADB behind an HTTP proxy
@@ -300,19 +307,19 @@ NOTE: Currently, only HTTP and HTTPS proxy servers are supported.
 
 For Linux, OS X and Windows Cygwin shell:
 
-....
+----
 export PROXY="<proxy_server>:<port>"
 export PROXY_USER="foo"
 export PROXY_PASSWORD="mysecretpass"
-....
+----
 
 For Windows CMD or Powershell:
 
-....
+----
 setx PROXY="<proxy_server>:<port>"
 setx PROXY_USER="foo"
 setx PROXY_PASSWORD="mysecretpass"
-....
+----
 
 At this point your Atomic Developer Bundle installation is complete. You
 can find link:using.adoc[ADB Usage Information] in the documentation

--- a/docs/troubleshooting.adoc
+++ b/docs/troubleshooting.adoc
@@ -8,16 +8,31 @@ Use this document to identify and resolve basic ADB issues that you encounter.
 toc::[]
 '''
 
-== Troubleshooting Landrush
-https://github.com/vagrant-landrush/landrush/blob/master/README.md[Landrush] is a platform-agnostic DNS server used by ADB to provide name based
-access to services, such as Openshift, running in the ADB.
+== Installation and Update
+
+This section contains issues related to installing, configuring, and updating ADB.
+
+=== On a Windows machine, Vagrant fails to initialize after updating to the latest ADB version
+
+In addition to the standard link:updating.adoc[steps to update ADB], you need to run the
+following command to delete the .vagrant.d directory:
+
+----
+# rm -rf C:/Users/<user_name>/.vagrant.d/
+----
+
+== Landrush
+
+https://github.com/vagrant-landrush/landrush/blob/master/README.md[Landrush] is a
+platform-agnostic DNS server used by ADB to provide name based access to services,
+such as Openshift, running in ADB.
 
 In ADB, you use Landrush as a vagrant plugin. Refer to the
 link:installing.rst[Installation document] for details on downloading
 Landrush.
 
 
-=== I am unable to access the Internet or override the Landrush upstream DNS? +
+=== I am unable to access the Internet or override the Landrush upstream DNS
 
 By default, Landrush uses Google's DNS server, with the IP address
 8.8.8.8, to resolve DNS queries that are not for Landrush managed
@@ -38,9 +53,9 @@ For further details, refer to the *Guest is unable to access the Internet* and
 the *Unmatched Queries* sections in the https://github.com/vagrant-landrush/landrush/blob/master/README.md[Landrush documentation].
 
 
-=== I cannot access OpenShift console from my browser. +
+=== I cannot access the OpenShift console from my browser
 
-Landrush enables you to access services running in the ADB, such as
+Landrush enables you to access services running in ADB, such as
 OpenShift, from the browser. When you start ADB, it provides Landrush
 with the IP address and the hostname it wishes to use. Landrush always
 uses the latest information available. Occasionally, using multiple
@@ -81,7 +96,7 @@ cdk                            cdk.vm
 ....
 
 
-=== OpenShift Web console fails to reconnect when you switch networks or reconnect to VPN. +
+=== OpenShift Web console fails to reconnect when you switch networks or reconnect to VPN
 
 Linux users are most likely to encounter this problem because
 **NetworkManager** overwrites Landrush’s entry in the `/etc/resolve.conf` file, on enterprise Linux. The **NetworkManager** controls the
@@ -97,7 +112,7 @@ nameserver 127.0.0.1
 ....
 
 
-=== I use libvirt and am unable to connect to the OpenShift console or the other applications running in the ADB, or I use Libvirt but want to use VirtualBox for ADB. +
+=== I use libvirt and am unable to connect to the OpenShift console or the other applications running in ADB, or I use Libvirt but want to use VirtualBox for ADB
 
 Linux users may be affected by this issue. If you use libvirt provider,
 `libvirtd` uses `dnsmasq` as part of it's internal DNS resolution for
@@ -109,7 +124,6 @@ libvirt.
 Perform these steps to resolve this issue:
 
 NOTE: The following steps must be run as root.
-
 
 . Stop the libvirt and dnsmasq process:
 +

--- a/docs/updating.adoc
+++ b/docs/updating.adoc
@@ -2,7 +2,7 @@
 :toc:
 :toc-placement!:
 
-Depending on your implementation of the ADB, you might be able to
+Depending on your implementation of ADB, you might be able to
 directly update your Vagrant box. In some cases, you will need to
 perform a clean installation or follow additional steps to complete the
 update.
@@ -66,13 +66,6 @@ clean installation.
 
 . Monitor the mailing list and other announcement points to determine
 if a new image is available.
-
-. If you are updating ADB on a Windows machine, run the following
-command to delete the .vagrant.d directory:
-+
-....
-# rm -rf C:/Users/<user_name>/.vagrant.d/
-....
 
 . Download the latest image and perform a clean install as described
 in the link:installing.adoc[installation documentation].

--- a/docs/using.adoc
+++ b/docs/using.adoc
@@ -57,7 +57,9 @@ environment variables or configuration information.
 
 To use ADB with Host-Based tools:
 
-. Install the vagrant-service-manager plugin. :
+=== Install and configure Vagrant and plugins
+
+. Install the vagrant-service-manager plugin:
 +
 ....
 vagrant plugin install vagrant-service-manager
@@ -100,11 +102,13 @@ the version of the image to be used.
 .  Start ADB using `vagrant up`. You will find detailed installation
 instructions in the link:docs/installing.adoc[Installation document].
 
-.  Configure the environment and download the required TLS certificates
+=== Configure your environment
+
+Configure the environment and download the required TLS certificates
 using the plugin. The example below shows the command and the output for
 Linux and Mac OS X. On Microsoft Windows the output may vary depending
 on the execution environment:
-+
+
 ....
 $ vagrant service-manager env
 # docker env:
@@ -118,10 +122,10 @@ export DOCKER_API_VERSION=1.21
 # run following command to configure your shell:
 # eval "$(vagrant service-manager env)"
 ....
-+
+
 Setting these environment variables allows programs, such as Eclipse and
 the docker CLI to access the docker daemon.
-+
+
 [NOTE]
 ====
 When the OpenShift service is running in the VM, a Docker
@@ -140,18 +144,17 @@ export DOCKER_REGISTRY=hub.openshift.centos7-adb.10.1.2.2.xip.io
 ....
 ====
 
-.  Begin developing.
-+
-If you do not have the docker CLI, you can use the `install-cli` command
-as:
-+
+=== Develop your application with the CLI
+
+If you do not have the docker CLI, you can use the `install-cli` command:
+
 ....
 $ vagrant service-manager install-cli docker
 ....
-+
+
 However, if you are using the docker CLI, you can just run it from the
 command line and it will work as expected.
-+
+
 [NOTE]
 ====
 If you encounter a Docker client and server version mismatch such as:
@@ -165,22 +168,28 @@ not the same. Typically, you will need to try the previous release (i.e.
 if you get this error message using a docker 1.9 CLI, try a docker 1.8
 CLI).
 ====
-+
 
-. If you are using Eclipse, you should follow these steps:
-..  Install the
+=== Configure Eclipse
+
+If you are using Eclipse, you should follow these steps:
+
+.  Install the
 http://www.eclipse.org/community/eclipse_newsletter/2015/june/article3.php[Docker
 Tooling] plugin.
-..  Enable the three Docker Views (Docker Explorer, Docker Containers,
+
+.  Enable the three Docker Views (Docker Explorer, Docker Containers,
 and Docker Images) by choosing **Windows -> Show Views -> Others**.
-..  Enable the Console by choosing **Windows -> Show Views -> Console**.
-..  In the **Docker Explorer** view, click to add a connection and provide
+
+.  Enable the Console by choosing **Windows -> Show Views -> Console**.
+
+.  In the **Docker Explorer** view, click to add a connection and provide
 a connection name. If your environment variables are set correctly, the
 remaining fields will auto-populate. If not, using the output from
 `vagrant service-manager env docker`, put the DOCKER_HOST variable in the
 **TCP Connection** field and the DOCKER_CERT_PATH variable in the
 **Authentication Section** path.
-..  You can test the connection and then accept the results. At this
+
+.  You can test the connection and then accept the results. At this
 point, you are ready to use ADB with Eclipse.
 +
 NOTE: Testing has been done with Eclipse 4.5.0.
@@ -238,44 +247,53 @@ continuously sync the folder while the guest is running.
 The following synced folder types work out of the box with the ADB
 Vagrant box, for both Virtualbox as well as Libvirt/KVM :
 
-* https://github.com/dustymabe/vagrant-sshfs[vagrant-sshfs]: Works with
+vagrant-sshfs::
+https://github.com/dustymabe/vagrant-sshfs[vagrant-sshfs] works with
 Linux/GNU, OS X and Microsoft Windows. It is the recommended choice for
 enabling synced folders and the
 link:#using-custom-vagrantfiles-for-specific-use-cases[custom
-Vagrantfile examples] use it per default. In the suggested default
+Vagrantfile examples] use it per default.
++
+In the suggested default
 configuration, your home directory on the host (for example,
 `/home/john`) is synced to the equivalent path on the guest VM
 (`/home/john`). For Windows users, there is a little caveat, their home
 directory (for example, C:\Users\john) must be mapped to a Unix style
 path (`/c/users/john`).
-* https://www.vagrantup.com/docs/synced-folders/nfs.html[NFS]: Works
+
+nfs::
+https://www.vagrantup.com/docs/synced-folders/nfs.html[NFS] works
 with Linux/GNU and OS X.
 
-There are also some other alternatives, which are, however, not yet
-properly tested with ADB.
+The following folder types are not officially supported but are available as-is:
 
-* https://www.vagrantup.com/docs/synced-folders/smb.html[SMB]: For
-Microsoft Windows.
-** You need to install cifs-utils RPM inside ADB, for the SMB synced
+SMB::
+https://www.vagrantup.com/docs/synced-folders/smb.html[SMB] works for
+Microsoft Windows. This folder type is not officially supported for ADB.
++
+You need to install cifs-utils RPM inside ADB, for the SMB synced
 folder type to work:
 +
 ....
 sudo yum install cifs-utils
 ....
-* https://www.virtualbox.org/manual/ch04.html#sharedfolders[Virtualbox
-shared folder]: For Virtualbox users with Virtualbox guest additions.
-** At this point of time Virtualbox guest additions do not come
-pre-installed in the ADB Vagrant box.
-** For installation details, please refer to
+
+VirtualBox shared folder::
+https://www.virtualbox.org/manual/ch04.html#sharedfolders[Virtualbox
+shared folder] for Virtualbox users with Virtualbox guest additions. Currently
+Virtualbox guest additions do not come pre-installed in the ADB Vagrant box.
++
+For installation details, please refer to
 https://www.virtualbox.org/manual/ch04.html[Virtualbox documentation].
-** You can also use
+You can also use
 https://github.com/dotless-de/vagrant-vbguest[vagrant-vbguest] plugin to
 install Virtualbox guest additions in ADB Vagrant box.
 
 [[some-useful-commands]]
 == Some useful commands
 
-* `vagrant halt` - Stop the vagrant box, temporarily:
+`vagrant halt`::
+Stops the vagrant box temporarily.
 +
 You can use `vagrant halt` to gracefully stop the vagrant box and
 continue with your work when you start next with `vagrant up`. This will
@@ -283,11 +301,15 @@ not cause any loss of data. It is recommended to stop the vagrant box
 before you shutdown your machine, to save CPU and RAM consumption. Also,
 powering off your machine without stopping the vagrant box, could cause
 errors when you resume using it.
-* `vagrant status` - Check the Status of the Vagrant box:
+
+`vagrant status`::
+Checks the Status of the Vagrant box.
 +
 Use `vagrant status` to check the status of ADB and to check which
 virtualization provider is being used and the status of the provider.
-* `vagrant destroy` - Destroy the Vagrant box:
+
+`vagrant destroy`::
+Destroys the Vagrant box permanently.
 +
 WARNING: Using `vagrant destroy` will destroy any data you stored in
 the Vagrant box. You will not be able to restart this instance and will


### PR DESCRIPTION
Fixes #524 

This PR includes a collection of style, format, and structure fixes that address the following requests in the above issue:

- Restructured the installation and usage guides to remove mega-deep-nested lists for easier skimming/chunking.
- Restructured the troubleshooting guide to include workaround for Windows machine per request in https://github.com/projectatomic/adb-atomic-developer-bundle/issues/500#issuecomment-242678929
- Adjusted code block formatting to match downstream style guide
- Added links to new content from the readme and link to contribution document
- Removed "the" before ADB where it is not needed
- Searched for refereneces to Fedora 22 (none found)
