### PR TITLE
Fixed section IDs and relative links to other docs

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -11,8 +11,8 @@ orchestrators while providing a path that promotes best practices.
 '''
 toc::[]
 '''
-
-== Advantage of ADB
+[[advantages]]
+== Advantages of ADB
 
 As a container developer, you want to use ADB for these reasons:
 
@@ -42,7 +42,7 @@ instead of reinventing the wheel.
 ADB is a virtual machine that is executed with Vagrant and some Vagrant
 plugins.
 
-[[when-would-adb-typically-be-used]]
+[[when-to-use]]
 == When would ADB typically be used?
 
 A developer begins using ADB, in most cases, once they have a working
@@ -67,7 +67,7 @@ Alternatively, build a Nulecule description of the application.
 The http://docs.projectatomic.io/container-best-practices/[Container
 Best Practices] document in this project may also be of interest.
 
-[[what-is-the-typical-usage-pattern]]
+[[typical-usage-pattern]]
 == What is the typical usage pattern?
 
 ADB supports three basic modes of usage. The modes vary by how much they
@@ -96,7 +96,7 @@ all of the software ADB ships with.
 
 More information about link:docs/using.adoc[using ADB] is available.
 
-[[what-does-adb-utilize]]
+[[adb-related-projects]]
 == What does ADB utilize?
 
 ADB is built on top of https://www.centos.org/[CentOS 7] and the
@@ -129,7 +129,7 @@ You need to use the customized Vagrantfiles provided in ADB project to
 set up the above mentioned environments. For further details refer to
 the Installation steps in the next section.
 
-[[how-do-i-install-and-run-adb]]
+[[quick-install-run]]
 == How do I install and run ADB?
 
 Below is an installation overview using the most common options.
@@ -152,15 +152,13 @@ $ vagrant plugin install vagrant-service-manager vagrant-sshfs landrush
 Some operating systems may need additional dependencies to be
 installed before you proceed with the installation of the vagrant
 plugins. For details refer to the detailed
-https://github.com/projectatomic/adb-atomic-developer-bundle/blob/master/docs/installing.adoc[Installation
-document].
+link:docs/installing.adoc[Installation document].
 
 . Download the customized Vagrantfiles provided by the ADB project.
 These Vagrantfiles will download ADB and automatically set up
 provider-specific container development environments. They are listed
 below and more details are available in the
-https://github.com/projectatomic/adb-atomic-developer-bundle/blob/master/docs/installing.adoc[Installation
-document].
+link:docs/installing.adoc[Installation document].
 +
 To download ADB and set up a provider-specific container development
 environment:
@@ -228,7 +226,7 @@ Additional goals, objectives and work in progress can be found on the
 Project Atomic https://trello.com/b/j1rEolFe/container-tools[trello
 board].
 
-[[deliverables-and-downloading]]
+[[deliverables]]
 == What are the deliverables and where are they delivered?
 
 ADB is delivered as a Vagrant box for various (currently libvirt and
@@ -252,7 +250,7 @@ specific build requirements that are not enabled in those boxes.
 * link:docs/updating.adoc[Updating ADB]
 * link:docs/building.adoc[Building the Vagrant box] for Developers
 
-[[interested-in-contributing-to-this-project]]
+[[contributing]]
 == Interested in Contributing to this project?
 
 We welcome new ideas, suggestions, issues and pull requests. Want to be
@@ -273,6 +271,7 @@ http://asciidoctor.org/docs/editing-asciidoc-with-live-preview/[live preview].
 For detailed information about contributing to the projects,
 see link:CONTRIBUTING.adoc[how to contribute].
 
+[[additional-resources]]
 == Additional online resources
 
 * Using OpenShift in ADB:

--- a/components/centos/centos-docker-base-setup/README.adoc
+++ b/components/centos/centos-docker-base-setup/README.adoc
@@ -12,8 +12,7 @@ docker tooling] or the docker CLI, with ADB.
 == Quickstart
 
 .  Get latest ADB box and add it to vagrant as described in
-link:../../../docs/installing.adoc[Installing the Atomic Developer
-Bundle].
+link:../../../docs/installing.adoc[Installing Atomic Developer Bundle].
 
 .  Create a directory for the Vagrant Box.
 +
@@ -33,5 +32,4 @@ $ curl -sL https://raw.githubusercontent.com/projectatomic/adb-atomic-developer-
 $ vagrant up
 ----
 
-.  Proceed with using ADB as described in link:../../../docs/using.adoc[Using
-Atomic Developer Bundle].
+.  Proceed with using ADB as described in link:../../../docs/using.adoc[Using Atomic Developer Bundle].

--- a/components/centos/centos-k8s-singlenode-setup/README.adoc
+++ b/components/centos/centos-k8s-singlenode-setup/README.adoc
@@ -15,8 +15,7 @@ docker tooling] or the kubernetes and docker CLIs, with ADB.
 == Quickstart
 
 .  Get the latest ADB box and add it to vagrant as described in
-link:../../../docs/installing.adoc[Installing Atomic Developer
-Bundle].
+link:../../../docs/installing.adoc[Installing Atomic Developer Bundle].
 
 .  Create a directory for the Vagrant Box.
 +
@@ -36,8 +35,7 @@ $ curl -sL https://raw.githubusercontent.com/projectatomic/adb-atomic-developer-
 $ vagrant up
 ----
 
-.  Proceed with using ADB as described in link:../../../docs/using.adoc[Using
-Atomic Developer Bundle].
+.  Proceed with using ADB as described in link:../../../docs/using.adoc[Using Atomic Developer Bundle].
 
 [[verifying-the-installation]]
 == Verifying the installation

--- a/components/centos/centos-mesos-marathon-singlenode-setup/README.adoc
+++ b/components/centos/centos-mesos-marathon-singlenode-setup/README.adoc
@@ -7,15 +7,13 @@ to the host. This Vagrantfile is based on
 https://atlas.hashicorp.com/projectatomic/boxes/adb[ADB] vagrant box. It
 sets up Mesos master & slave and Marathon on a CentOS 7 system. It uses
 the rpm packages for these from
-http://repos.mesosphere.com/el/7/noarch/RPMS/mesosphere-el-repo-7-1.noarch.rpm[Mesosphere
-repo].
+http://repos.mesosphere.com/el/7/noarch/RPMS/mesosphere-el-repo-7-1.noarch.rpm[Mesosphere repo].
 
 [[quickstart]]
 == Quickstart
 
 To setup a virtualization provider or to install Vagrant refer to the
-https://github.com/projectatomic/adb-atomic-developer-bundle/blob/master/docs/installing.adoc[ADB installation
-instructions].
+link:../../../docs/installing.adoc[Installing Atomic Developer Bundle].
 
 To bring up a Vagrant box using a different virtualization provider,
 replace `libvirt` in the following command with the provider of your choice.

--- a/components/centos/centos-openshift-setup/README.adoc
+++ b/components/centos/centos-openshift-setup/README.adoc
@@ -19,8 +19,7 @@ https://github.com/projectatomic/adb-atomic-developer-bundle/blob/v1.6.0/compone
 == Quickstart
 
 .  Get the latest ADB box and add it to vagrant as described in the
-https://github.com/projectatomic/adb-atomic-developer-bundle/blob/master/docs/installing.adoc[ADB
-installation instructions].
+link:../../../docs/installing.adoc[Installing Atomic Developer Bundle].
 
 .  Create a directory for the Vagrant Box.
 +
@@ -52,8 +51,7 @@ version] you need, for the variable. For instance, `IMAGE_TAG="v1.2.1"`
 $ vagrant up
 ----
 
-.  Proceed with using ADB as described in link:../../../docs/using.adoc[Using
-Atomic Developer Bundle].
+.  Proceed with using ADB as described in link:../../../docs/using.adoc[Using Atomic Developer Bundle].
 
 [additiona-openshit-config]
 == Additional configuration for OpenShift

--- a/components/rhel/README_CDK_ZIP.adoc
+++ b/components/rhel/README_CDK_ZIP.adoc
@@ -35,8 +35,8 @@ The `plugins` directory contains Vagrant plugins and respective README files:
 
 * `vagrant-registration`
   ** GitHub: https://github.com/projectatomic/adb-vagrant-registration
-  ** README: https://github.com/projectatomic/adb-vagrant-registration/blob/master/README.md
+  ** README: https://github.com/projectatomic/adb-vagrant-registration/blob/master/README.adoc
 
 * `vagrant-sshfs`
   ** GitHub: https://github.com/dustymabe/vagrant-sshfs
-  ** README: https://github.com/dustymabe/vagrant-sshfs/blob/master/README.md
+  ** README: https://github.com/dustymabe/vagrant-sshfs/blob/master/README.adoc

--- a/docs/cockpit.adoc
+++ b/docs/cockpit.adoc
@@ -11,7 +11,7 @@ Specifically for containers, it can:
 * Start and stop containers
 * Pull and delete images
 
-[[accessing-cockpit-in-the-adb]]
+[[accessing-cockpit]]
 == Accessing Cockpit in ADB
 
 These instructions are written assuming you are at a command prompt on

--- a/docs/installing.adoc
+++ b/docs/installing.adoc
@@ -8,7 +8,7 @@ This document describes how to install ADB and required dependencies.
 toc::[]
 '''
 
-[[install-a-virtualization-provider]]
+[[install-virt-provider]]
 == Step 1. Install a virtualization provider
 
 Two virtualization providers have been tested with ADB; VirtualBox and
@@ -34,7 +34,7 @@ The choice as to which to use should be driven by your preferences and
 environmental concerns and is outside of the scope of this document.
 Both will work equally well in their default configuration. You may wish
 to read the section on file synchronization in the
-https://github.com/projectatomic/adb-atomic-developer-bundle/blob/master/docs/using.adoc[Using ADB documentation] when making this decision.
+link:using.adoc[Using ADB documentation] when making this decision.
 
 * VirtualBox installation instructions are available
 https://www.virtualbox.org/manual/ch02.html#startingvboxonlinux[online
@@ -67,7 +67,7 @@ The choice as to which to use should be driven by your preferences and
 environmental concerns and is outside of the scope of this document.
 Both will work equally well in their default configuration. You may wish
 to read the section onfile synchronization in the
-https://github.com/projectatomic/adb-atomic-developer-bundle/blob/master/docs/using.adoc[Using ADB documentation] when making this decision.
+link:using.adoc[Using ADB documentation] when making this decision.
 
 * VirtualBox installation instructions are available
 https://www.virtualbox.org/manual/ch02.html#startingvboxonlinux[online
@@ -163,7 +163,7 @@ $ sudo systemctl start libvirtd
 $ sudo systemctl enable libvirtd
 ----
 
-[[install-additional-dependencies]]
+[[install-dependencies]]
 == Step 3. Install additional dependencies
 
 For some operating systems, you might need to install additional
@@ -285,7 +285,7 @@ export BOX=<box-name>
 ----
 ====
 
-[[set-up-adb-behind-an-http-proxy]]
+[[adb-behind-http-proxy]]
 == Step 6. (Optional) Set up ADB behind an HTTP proxy
 
 ADB can be set up behind a proxy server. Set the following proxy parameters in the
@@ -303,13 +303,14 @@ In an unauthenticated proxy environment, the `proxy_user` and `proxy_password`
 configurations can be omitted.
 
 == Step 7. Start ADB
+
 Start ADB by running the `vagrant up` command.
 
 ----
 $ vagrant up
 ----
 
-This will start the ADB and set it up to work with the provider of
+This will start ADB and set it up to work with the provider of
 choice, for use with host-based tools or via `vagrant ssh`.
 
 [NOTE]
@@ -321,7 +322,6 @@ $ vagrant up --provider virtualbox
 ----
 ====
 
-At this point your Atomic Developer Bundle installation is complete. You may wish
-to review the link:docs/using.adoc[Using Atomic Developer
-Bundle] documentation before starting ADB, especially if you are using
-host-based tools.
+At this point your Atomic Developer Bundle installation is complete. You
+can find link:using.adoc[ADB usage information] in the documentation
+directory.

--- a/docs/troubleshooting.adoc
+++ b/docs/troubleshooting.adoc
@@ -7,7 +7,7 @@ Use this document to identify and resolve basic ADB issues that you encounter.
 '''
 toc::[]
 '''
-
+[[install-update]]
 == Installation and Update
 
 This section contains issues related to installing, configuring, and updating ADB.
@@ -21,6 +21,7 @@ following command to delete the .vagrant.d directory:
 # rm -rf C:/Users/<user_name>/.vagrant.d/
 ----
 
+[[landrrush]]
 == Landrush
 
 https://github.com/vagrant-landrush/landrush/blob/master/README.md[Landrush] is a
@@ -28,7 +29,7 @@ platform-agnostic DNS server used by ADB to provide name based access to service
 such as Openshift, running in ADB.
 
 In ADB, you use Landrush as a vagrant plugin. Refer to the
-link:installing.rst[Installation document] for details on downloading
+link:installing.adoc[Installation document] for details on downloading
 Landrush.
 
 

--- a/docs/updating.adoc
+++ b/docs/updating.adoc
@@ -28,7 +28,7 @@ not saved on your host machine:
 # vagrant destroy
 ....
 
-[[update-adb-from-atlas.hashicorp.com]]
+[[update-from-atlas-hashicorp]]
 == Update ADB from atlas.hashicorp.com
 
 If you use ADB images from atlas.hashicorp.com, you can perform a direct
@@ -57,7 +57,7 @@ command:
 # vagrant box update
 ....
 
-[[update-adb-from-cloud.centos.org]]
+[[update-from-cloud-centos]]
 == Update ADB from cloud.centos.org
 
 If you use ADB images from cloud.centos.org, you must manually remove

--- a/docs/using.adoc
+++ b/docs/using.adoc
@@ -33,11 +33,12 @@ Once you start ADB you can use it as:
 * a Linux virtual machine.
 
 For a quick high level glimpse at ADB and how you can use it refer to
-the https://github.com/projectatomic/adb-atomic-developer-bundle/blob/master/README.adoc[Readme].
-For detailed instructions on how to install ADB refer to the
-link:docs/installing.adoc[Installation Document].
+the link:../README.adoc[Readme].
 
-[[using-adb-with-host-based-tools-eclipse-and-clis]]
+For detailed instructions on how to install ADB refer to the
+link:installing.adoc[Installation Document].
+
+[[using-host-based-tools]]
 == Using ADB with host-based tools (Eclipse and CLIs)
 
 Many users have preferred development environments built from tools
@@ -100,7 +101,7 @@ Specifies the image to be used.
 the version of the image to be used.
 
 .  Start ADB using `vagrant up`. You will find detailed installation
-instructions in the link:docs/installing.adoc[Installation document].
+instructions in the link:installing.adoc[Installation document].
 
 === Configure your environment
 
@@ -194,7 +195,7 @@ point, you are ready to use ADB with Eclipse.
 +
 NOTE: Testing has been done with Eclipse 4.5.0.
 
-[[using-the-vm-via-ssh]]
+[[using-ssh]]
 == Using the VM via SSH
 
 You can access the VM by using `ssh` to login to it with the following command:
@@ -214,7 +215,6 @@ to manage the orchestration services inside ADB. With `sccli`, you can start, st
 restart, and get the status of orchestration providers like OpenShift, Docker,
 and Kubernetes.
 
-[[using-atomic-app-and-nulecule]]
 === Using Atomic App and Nulecule
 
 You can use Atomic App and Nulecule to run ADB. Details on these projects can be
@@ -289,7 +289,7 @@ You can also use
 https://github.com/dotless-de/vagrant-vbguest[vagrant-vbguest] plugin to
 install Virtualbox guest additions in ADB Vagrant box.
 
-[[some-useful-commands]]
+[[useful-commands]]
 == Some useful commands
 
 `vagrant halt`::


### PR DESCRIPTION
Fixes #553 

This PR addresses the following issues:

- Fix section/topic IDs after asciidoc conversion (many of them were long and clumsy)
- Fix links to other docs in the repo to be relative (instead of hard-coded) to allow them to parse into HTML links when we publish docs later
- Fixed links that were broken due to line breaks 
- Minimize links to other repos (only a handful of them are currently used and only when absolutely necessary)

Reviews welcome!